### PR TITLE
fix: disable unused tools in binder design page

### DIFF
--- a/src/app/pages/binder-design/binder-design.html
+++ b/src/app/pages/binder-design/binder-design.html
@@ -32,6 +32,7 @@
           widthClass="w-auto"
           borderRadius="rounded-3xl"
           colorClasses="!px-6 !py-3 text-sm font-medium shadow-md hover:translate-y-0.5 !border-0 !bg-white !text-blue-900 hover:!text-gray-700"
+          [disabled]="workflow.disabled"
           (click)="navigateToWorkflow(workflow.id)"
         >
           {{ workflow.label }}
@@ -50,6 +51,7 @@
           widthClass="w-auto"
           borderRadius="rounded-3xl"
           colorClasses="!px-6 !py-3 text-sm font-medium shadow-md hover:translate-y-0.5 !border-0 !bg-white !text-blue-900 hover:!text-gray-700"
+          [disabled]="tool.disabled"
           (click)="navigateToTool(tool.id)"
         >
           {{ tool.label }}

--- a/src/app/pages/binder-design/binder-design.spec.ts
+++ b/src/app/pages/binder-design/binder-design.spec.ts
@@ -48,6 +48,7 @@ describe("BinderDesignComponent", () => {
       expect(motifWorkflow).toBeDefined();
       expect(motifWorkflow?.label).toBe("Motif Scaffolding");
       expect(motifWorkflow?.href).toBe("/motif-scaffolding");
+      expect(motifWorkflow?.disabled).toBeTrue();
     });
 
     it("workflows should contain partial diffusion workflow", () => {
@@ -57,6 +58,7 @@ describe("BinderDesignComponent", () => {
       expect(partialWorkflow).toBeDefined();
       expect(partialWorkflow?.label).toBe("Partial Diffusion");
       expect(partialWorkflow?.href).toBe("/partial-diffusion");
+      expect(partialWorkflow?.disabled).toBeTrue();
     });
 
     it("should have all workflows with required properties", () => {
@@ -83,7 +85,7 @@ describe("BinderDesignComponent", () => {
       );
       expect(bindCraftTool).toBeDefined();
       expect(bindCraftTool?.id).toBe("bindcraft");
-      expect(bindCraftTool?.href).toBe("/tools/bindcraft");
+      expect(bindCraftTool?.href).toBe("/de-novo-design");
     });
 
     it("tools should contain RFdiffusion tool", () => {
@@ -93,6 +95,7 @@ describe("BinderDesignComponent", () => {
       expect(rfdiffusionTool).toBeDefined();
       expect(rfdiffusionTool?.id).toBe("rfdiffusion");
       expect(rfdiffusionTool?.href).toBe("/tools/rfdiffusion");
+      expect(rfdiffusionTool?.disabled).toBeTrue();
     });
 
     it("tools should contain BoltzGen tool", () => {
@@ -100,6 +103,7 @@ describe("BinderDesignComponent", () => {
       expect(boltzGenTool).toBeDefined();
       expect(boltzGenTool?.id).toBe("boltzgen");
       expect(boltzGenTool?.href).toBe("/tools/boltzgen");
+      expect(boltzGenTool?.disabled).toBeTrue();
     });
     it("should have all tools with required properties", () => {
       component.tools.forEach((tool) => {
@@ -208,7 +212,7 @@ describe("BinderDesignComponent", () => {
 
     describe("navigateToWorkflow", () => {
       it("should navigate to the specified workflow", () => {
-        const workflowId = "motif-scaffolding";
+        const workflowId = "de-novo-design";
 
         component.navigateToWorkflow(workflowId);
 
@@ -222,11 +226,7 @@ describe("BinderDesignComponent", () => {
       });
 
       it("should handle navigation to each workflow", () => {
-        const workflowIds = [
-          "de-novo-design",
-          "motif-scaffolding",
-          "partial-diffusion",
-        ];
+        const workflowIds = ["de-novo-design"];
 
         workflowIds.forEach((workflowId) => {
           component.navigateToWorkflow(workflowId);
@@ -236,16 +236,23 @@ describe("BinderDesignComponent", () => {
 
         expect(mockRouter.navigate).toHaveBeenCalledTimes(workflowIds.length);
       });
+
+      it("should not navigate for disabled workflows", () => {
+        component.navigateToWorkflow("motif-scaffolding");
+        component.navigateToWorkflow("partial-diffusion");
+
+        expect(mockRouter.navigate).not.toHaveBeenCalled();
+      });
     });
 
     describe("navigateToTool", () => {
       it("should navigate to the specified tool", () => {
-        const toolId = "rfdiffusion";
+        const toolId = "bindcraft";
 
         component.navigateToTool(toolId);
 
         // Check router navigation was called
-        expect(mockRouter.navigate).toHaveBeenCalledWith(["/tools", toolId]);
+        expect(mockRouter.navigate).toHaveBeenCalledWith(["/de-novo-design"]);
 
         // Check console log
         expect(console.log).toHaveBeenCalledWith(
@@ -254,15 +261,22 @@ describe("BinderDesignComponent", () => {
       });
 
       it("should handle navigation to each tool", () => {
-        const toolIds = ["bindcraft", "rfdiffusion", "boltzgen"];
+        const toolIds = ["bindcraft"];
 
         toolIds.forEach((toolId) => {
           component.navigateToTool(toolId);
 
-          expect(mockRouter.navigate).toHaveBeenCalledWith(["/tools", toolId]);
+          expect(mockRouter.navigate).toHaveBeenCalledWith(["/de-novo-design"]);
         });
 
         expect(mockRouter.navigate).toHaveBeenCalledTimes(toolIds.length);
+      });
+
+      it("should not navigate for disabled tools", () => {
+        component.navigateToTool("rfdiffusion");
+        component.navigateToTool("boltzgen");
+
+        expect(mockRouter.navigate).not.toHaveBeenCalled();
       });
     });
 

--- a/src/app/pages/binder-design/binder-design.ts
+++ b/src/app/pages/binder-design/binder-design.ts
@@ -14,16 +14,28 @@ export class BinderDesignComponent {
 
   // Navigation methods
   navigateToWorkflow(workflowId: string) {
-    console.log(`Navigating to workflow: ${workflowId}`);
+    const workflow = this.workflows.find((item) => item.id === workflowId);
+    if (!workflow || workflow.disabled) {
+      return;
+    }
 
-    // Navigate to the workflow route
+    console.log(`Navigating to workflow: ${workflowId}`);
     this.router.navigate([`/${workflowId}`]);
   }
 
   navigateToTool(toolId: string) {
+    const tool = this.tools.find((item) => item.id === toolId);
+    if (!tool || tool.disabled) {
+      return;
+    }
+
     console.log(`Navigating to tool: ${toolId}`);
 
-    // Navigate to the tool route
+    if (toolId === "bindcraft") {
+      this.router.navigate(["/de-novo-design"]);
+      return;
+    }
+
     this.router.navigate(["/tools", toolId]);
   }
 
@@ -42,11 +54,13 @@ export class BinderDesignComponent {
       id: "motif-scaffolding",
       label: "Motif Scaffolding",
       href: "/motif-scaffolding",
+      disabled: true,
     },
     {
       id: "partial-diffusion",
       label: "Partial Diffusion",
       href: "/partial-diffusion",
+      disabled: true,
     },
   ];
 
@@ -55,17 +69,19 @@ export class BinderDesignComponent {
     {
       id: "bindcraft",
       label: "BindCraft",
-      href: "/tools/bindcraft",
+      href: "/de-novo-design",
     },
     {
       id: "rfdiffusion",
       label: "RFdiffusion",
       href: "/tools/rfdiffusion",
+      disabled: true,
     },
     {
       id: "boltzgen",
       label: "BoltzGen",
       href: "/tools/boltzgen",
+      disabled: true,
     },
   ];
 


### PR DESCRIPTION
Disable unavailable workflows: Motif Scaffolding, Partial Diffusion and tools: RFdiffusion, BoltzGen
<img width="1469" height="823" alt="Screenshot 2026-03-05 at 4 06 58 pm" src="https://github.com/user-attachments/assets/1c2e0faa-6576-4ae9-a74a-3177fae73903" />
