### PR TITLE
fix: report url

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "@ng-icons/lucide": "^32.2.0",
         "@ng-icons/simple-icons": "^32.2.0",
         "@ng-icons/tabler-icons": "^32.2.0",
+        "als-normalize-urlpath": "^2.3.0",
         "date-fns": "^4.1.0",
         "playwright": "^1.56.0",
         "rxjs": "~7.8.0",
@@ -593,6 +594,7 @@
       "integrity": "sha512-5Vyo/VJ1DrIsAkudFpZj1f7CpCLYuiTzTQksHTiZE18iYsLKRkEC7y9S6+TiHrdD96rhNxL28Pz9FDU4lIBjkw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@angular-eslint/bundled-angular-compiler": "20.4.0",
         "eslint-scope": "^8.0.2"
@@ -622,6 +624,7 @@
       "resolved": "https://registry.npmjs.org/@angular/animations/-/animations-20.3.4.tgz",
       "integrity": "sha512-b+vFsTtMYtOrcZZLXB4BxuErbrLlShFT6khTvkwu/pFK8ri3tasyJGkeKRZJHao5ZsWdZSqV2mRwzg7vphchnA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -771,6 +774,7 @@
       "resolved": "https://registry.npmjs.org/@angular/common/-/common-20.3.4.tgz",
       "integrity": "sha512-hBQahyiHEAtc30a8hPOuIWcUL7j8189DC0sX4RiBd/wtvzH4Sd3XhguxyZAL6gHgNZEQ0nKy0uAfvWB/79GChQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -787,6 +791,7 @@
       "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-20.3.4.tgz",
       "integrity": "sha512-ISfEyn5ppWOP2hyZy0/IFEcQOaq5x1mXVZ2CRCxTpWyXYzavj27Ahr3+LQHPVV0uTNovlENyPAUnrzW+gLxXEw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -800,6 +805,7 @@
       "integrity": "sha512-FwEv+QM9tEMXDMd2V+j82VLOjJVUrI7ENz/LJa2p/YEGVJQkT3HVca5qJj+8I+7bfPEY/d46R/cmjjqMqUcYdg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/core": "7.28.3",
         "@jridgewell/sourcemap-codec": "^1.4.14",
@@ -832,6 +838,7 @@
       "resolved": "https://registry.npmjs.org/@angular/core/-/core-20.3.4.tgz",
       "integrity": "sha512-qLYVXcpSBmsA/9fITB1cT2y37V1Yo3ybWEwvafnbAh8izabrMV0hh+J9Ajh9bPk092T7LS8Xt9eTu0OquBXkbw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -875,6 +882,7 @@
       "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-20.3.4.tgz",
       "integrity": "sha512-8eoHC+vk7scb24qjlpsirkh1Q17uFyWdhl+u92XNjvimtZRY96oDZeFEDPoexPqtKUQcCOpEPbL8P/IbpBsqYQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -915,6 +923,7 @@
       "resolved": "https://registry.npmjs.org/@angular/router/-/router-20.3.4.tgz",
       "integrity": "sha512-qMVurWXVplYeHBKOWtQFtD+MfwOc0i/VJaFPGdiM5mDlfhtsg3OHcZBbSTmQW02l/4YimF5Ee3+pac279p+g1A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -985,6 +994,7 @@
       "integrity": "sha512-yDBHV9kQNcr2/sUr9jghVyz9C3Y5G2zUM2H2lo+9mKv4sFgbA8s8Z9t8D1jiTkGoO/NoIfKMyKWr4s6CN23ZwQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.27.1",
@@ -4084,6 +4094,7 @@
       "integrity": "sha512-nqhDw2ZcAUrKNPwhjinJny903bRhI0rQhiDz1LksjeRxqa36i3l75+4iXbOy0rlDpLJGxqtgoPavQjmmyS5UJw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@inquirer/checkbox": "^4.2.1",
         "@inquirer/confirm": "^5.1.14",
@@ -6544,6 +6555,7 @@
       "integrity": "sha512-2Q7WS25j4pS1cS8yw3d6buNCVJukOTeQ39bAnwR6sOJbaxvyCGebzTMypDFN82CxBLnl+lSWVdCCWbRY6y9yZQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -6709,6 +6721,7 @@
       "integrity": "sha512-BnOroVl1SgrPLywqxyqdJ4l3S2MsKVLDVxZvjI1Eoe8ev2r3kGDo+PcMihNmDE+6/KjkTubSJnmqGZZjQSBq/g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.46.2",
         "@typescript-eslint/types": "8.46.2",
@@ -6816,6 +6829,7 @@
       "integrity": "sha512-lNCWCbq7rpg7qDsQrd3D6NyWYu+gkTENkG5IKYhUIcxSb59SQC/hEQ+MrG4sTgBVghTonNWq42bA/d4yYumldQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
@@ -6859,6 +6873,7 @@
       "integrity": "sha512-sExxzucx0Tud5tE0XqR0lT0psBQvEpnpiul9XbGUB1QwpWJJAps1O/Z7hJxLGiZLBKMCutjTzDgmd1muEhBnVg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.7.0",
         "@typescript-eslint/scope-manager": "8.46.2",
@@ -7133,6 +7148,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -7221,6 +7237,7 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -7287,6 +7304,15 @@
       },
       "engines": {
         "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/als-normalize-urlpath": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/als-normalize-urlpath/-/als-normalize-urlpath-2.3.0.tgz",
+      "integrity": "sha512-bBU9TuebAaDDw3brWMM1PwvqZOtjYzkrbPd203ObWla4awV1WPS+MAnrF9KnGrFk2hYVA66pN9kcXecaUD4JrQ==",
+      "license": "ISC",
+      "dependencies": {
+        "transliteration": "^2.3.5"
       }
     },
     "node_modules/angular-eslint": {
@@ -7761,6 +7787,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.9",
         "caniuse-lite": "^1.0.30001746",
@@ -8585,6 +8612,7 @@
       "integrity": "sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "env-paths": "^2.2.1",
         "import-fresh": "^3.3.0",
@@ -9460,6 +9488,7 @@
       "integrity": "sha512-t5aPOpmtJcZcz5UJyY2GbvpDlsK5E8JqRqoKtfiKE3cNh437KIqfJr3A3AKf5k64NPx6d0G3dno6XDY05PqPtw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -9820,6 +9849,7 @@
       "integrity": "sha512-DT9ck5YIRU+8GYzzU5kT3eHGA5iL+1Zd0EutOmTE9Dtk+Tvuzd23VBU+ec7HPNSTxXYO55gPV/hq4pSBJDjFpA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.0",
@@ -11346,7 +11376,8 @@
       "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-4.6.1.tgz",
       "integrity": "sha512-VYz/BjjmC3klLJlLwA4Kw8ytk0zDSmbbDLNs794VnWmkcCB7I9aAL/D48VNQtmITyPvea2C3jdUMfc3kAoy0PQ==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/jest-diff": {
       "version": "30.2.0",
@@ -11481,6 +11512,7 @@
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -11612,6 +11644,7 @@
       "integrity": "sha512-LrtUxbdvt1gOpo3gxG+VAJlJAEMhbWlM4YrFQgql98FwF7+K8K12LYO4hnDdUkNjeztYrOXEMqgTajSWgmtI/w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@colors/colors": "1.5.0",
         "body-parser": "^1.19.0",
@@ -11743,6 +11776,7 @@
       "integrity": "sha512-i/zQLFrfEpRyQoJF9fsCdTMOF5c2dK7C7OmsuKg2D0YSsuZSfQDiLuaiktbuio6F2wiCsZSnSnieIQ0ant/uzQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "jasmine-core": "^4.1.0"
       },
@@ -12158,6 +12192,7 @@
       "integrity": "sha512-kdTwsyRuncDfjEs0DlRILWNvxhDG/Zij4YLO4TMJgDLW+8OzpfkdPnRgrsRuY1o+oaxJGWsps5f/RVBgGmmN0w==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "copy-anything": "^2.0.1",
         "parse-node-version": "^1.0.1",
@@ -12326,6 +12361,7 @@
       "integrity": "sha512-SL0JY3DaxylDuo/MecFeiC+7pedM0zia33zl0vcjgwcq1q1FWWF1To9EIauPbl8GbMCU0R2e0uJ8bZunhYKD2g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cli-truncate": "^4.0.0",
         "colorette": "^2.0.20",
@@ -14432,6 +14468,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -15446,6 +15483,7 @@
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
       "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -15502,6 +15540,7 @@
       "integrity": "sha512-9GUyuksjw70uNpb1MTYWsH9MQHOHY6kwfnkafC24+7aOMZn9+rVMBxRbLvw756mrBFbIsFg6Xw9IkR2Fnn3k+Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "chokidar": "^4.0.0",
         "immutable": "^5.0.2",
@@ -16684,6 +16723,7 @@
       "integrity": "sha512-6A2rnmW5xZMdw11LYjhcI5846rt9pbLSabY5XPxo+XWdxwZaFEn47Go4NzFiHu9sNNmr/kXivP1vStfvMaK1GQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
         "arg": "^5.0.2",
@@ -16915,6 +16955,7 @@
       "integrity": "sha512-+6erLbBm0+LROX2sPXlUYx/ux5PyE9K/a92Wrt6oA+WDAoFTdpHE5tCYCI5PNzq2y8df4rA+QgHLJuR4jNymsg==",
       "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
         "acorn": "^8.14.0",
@@ -17094,6 +17135,19 @@
         "node": ">=0.6"
       }
     },
+    "node_modules/transliteration": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/transliteration/-/transliteration-2.6.1.tgz",
+      "integrity": "sha512-hJ9BhrQAOnNTbpOr1MxsNjZISkn7ppvF5TKUeFmTE1mG4ZPD/XVxF0L0LUoIUCWmQyxH0gJpVtfYLAWf298U9w==",
+      "license": "MIT",
+      "bin": {
+        "slugify": "dist/bin/slugify",
+        "transliterate": "dist/bin/transliterate"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/tree-dump": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/tree-dump/-/tree-dump-1.1.0.tgz",
@@ -17157,6 +17211,7 @@
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -17206,7 +17261,8 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD"
+      "license": "0BSD",
+      "peer": true
     },
     "node_modules/tuf-js": {
       "version": "3.1.0",
@@ -17277,6 +17333,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -17556,6 +17613,7 @@
       "integrity": "sha512-4cKBO9wR75r0BeIWWWId9XK9Lj6La5X846Zw9dFfzMRw38IlTk2iCcUt6hsyiDRcPidc55ZParFYDXi0nXOeLQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.5.0",
@@ -17705,6 +17763,7 @@
       "integrity": "sha512-4JLXU0tD6OZNVqlwzm3HGEhAHufSiyv+skb7q0d2367VDMzrU1Q/ZeepvkcHH0rZie6uqEtTQQe0OEOOluH3Mg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",
@@ -17807,6 +17866,7 @@
       "integrity": "sha512-QcQ72gh8a+7JO63TAx/6XZf/CWhgMzu5m0QirvPfGvptOusAxG12w2+aua1Jkjr7hzaWDnJ2n6JFeexMHI+Zjg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/bonjour": "^3.5.13",
         "@types/connect-history-api-fallback": "^1.5.4",
@@ -18770,6 +18830,7 @@
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -18788,7 +18849,8 @@
       "version": "0.15.1",
       "resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.15.1.tgz",
       "integrity": "sha512-XE96n56IQpJM7NAoXswY3XRLcWFW83xe0BiAOeMD7K5k5xecOeul3Qcpx6GqEeeHNkW5DWL5zOyTbEfB4eti8w==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@ng-icons/lucide": "^32.2.0",
     "@ng-icons/simple-icons": "^32.2.0",
     "@ng-icons/tabler-icons": "^32.2.0",
+    "als-normalize-urlpath": "^2.3.0",
     "date-fns": "^4.1.0",
     "playwright": "^1.56.0",
     "rxjs": "~7.8.0",

--- a/src/app/cores/services/results.service.spec.ts
+++ b/src/app/cores/services/results.service.spec.ts
@@ -13,6 +13,7 @@ describe("ResultsService", () => {
   let service: ResultsService;
   let httpMock: HttpTestingController;
   let sanitizer: DomSanitizer;
+  const apiBase = environment.apiBaseUrl!.replace(/\/?$/, "/");
 
   beforeEach(() => {
     TestBed.configureTestingModule({
@@ -105,7 +106,7 @@ describe("ResultsService", () => {
     const trustedUrl = service.getSafeReportResourceUrl("./report.html");
 
     expect(sanitizer.sanitize(SecurityContext.RESOURCE_URL, trustedUrl)).toBe(
-      `${environment.apiBaseUrl}/report.html`
+      new URL("./report.html", apiBase).href
     );
   });
 
@@ -121,7 +122,17 @@ describe("ResultsService", () => {
     const trustedUrl = service.getSafeReportResourceUrl("?token=test-token");
 
     expect(sanitizer.sanitize(SecurityContext.RESOURCE_URL, trustedUrl)).toBe(
-      `${environment.apiBaseUrl}/?token=test-token`
+      new URL("?token=test-token", apiBase).href
+    );
+  });
+
+  it("should sanitize protocol-relative report URLs to about:blank", () => {
+    const trustedUrl = service.getSafeReportResourceUrl(
+      "//evil.example/report"
+    );
+
+    expect(sanitizer.sanitize(SecurityContext.RESOURCE_URL, trustedUrl)).toBe(
+      "about:blank"
     );
   });
 
@@ -166,6 +177,23 @@ describe("ResultsService", () => {
     previewReq.flush({
       runId: "job/1",
       url: "https://reports.example.test/job-1/report.html",
+    });
+  });
+
+  it("should sanitize cross-origin http report URLs to about:blank", () => {
+    service.getJobReportResourceUrl("job/1").subscribe((response) => {
+      expect(sanitizer.sanitize(SecurityContext.RESOURCE_URL, response)).toBe(
+        "about:blank"
+      );
+    });
+
+    const previewReq = httpMock.expectOne(
+      `${environment.apiBaseUrl}/api/results/job%2F1/report/preview`
+    );
+    expect(previewReq.request.method).toBe("POST");
+    previewReq.flush({
+      runId: "job/1",
+      url: "http://reports.example.test/job-1/report.html",
     });
   });
 

--- a/src/app/cores/services/results.service.spec.ts
+++ b/src/app/cores/services/results.service.spec.ts
@@ -93,6 +93,48 @@ describe("ResultsService", () => {
     );
   });
 
+  it("should sanitize blank report URLs to about:blank", () => {
+    const trustedUrl = service.getSafeReportResourceUrl("   ");
+
+    expect(sanitizer.sanitize(SecurityContext.RESOURCE_URL, trustedUrl)).toBe(
+      "about:blank"
+    );
+  });
+
+  it("should allow dot-relative preview report URLs", () => {
+    const trustedUrl = service.getSafeReportResourceUrl("./report.html");
+
+    expect(sanitizer.sanitize(SecurityContext.RESOURCE_URL, trustedUrl)).toBe(
+      `${environment.apiBaseUrl}/report.html`
+    );
+  });
+
+  it("should allow parent-relative preview report URLs", () => {
+    const trustedUrl = service.getSafeReportResourceUrl("../report.html");
+
+    expect(sanitizer.sanitize(SecurityContext.RESOURCE_URL, trustedUrl)).toBe(
+      `${new URL("../report.html", environment.apiBaseUrl).href}`
+    );
+  });
+
+  it("should allow query-only preview report URLs", () => {
+    const trustedUrl = service.getSafeReportResourceUrl("?token=test-token");
+
+    expect(sanitizer.sanitize(SecurityContext.RESOURCE_URL, trustedUrl)).toBe(
+      `${environment.apiBaseUrl}/?token=test-token`
+    );
+  });
+
+  it("should sanitize non-relative report URLs without an explicit scheme", () => {
+    const trustedUrl = service.getSafeReportResourceUrl(
+      "reports.example.test/job-1/report.html"
+    );
+
+    expect(sanitizer.sanitize(SecurityContext.RESOURCE_URL, trustedUrl)).toBe(
+      "about:blank"
+    );
+  });
+
   it("should return a trusted resource URL from the report endpoint URL", () => {
     service.getJobReportResourceUrl("job/1").subscribe((response) => {
       expect(sanitizer.sanitize(SecurityContext.RESOURCE_URL, response)).toBe(
@@ -110,10 +152,10 @@ describe("ResultsService", () => {
     });
   });
 
-  it("should sanitize cross-origin preview report URLs", () => {
+  it("should allow cross-origin https preview report URLs", () => {
     service.getJobReportResourceUrl("job/1").subscribe((response) => {
       expect(sanitizer.sanitize(SecurityContext.RESOURCE_URL, response)).toBe(
-        "about:blank"
+        "https://reports.example.test/job-1/report.html"
       );
     });
 
@@ -185,7 +227,7 @@ describe("ResultsService", () => {
     ).toBe(`${environment.apiBaseUrl}/api/results/job%2F1/report?token=t`);
   });
 
-  it("should sanitize cross-origin report URLs from getJobReport", () => {
+  it("should allow cross-origin https report URLs from getJobReport", () => {
     let result: unknown;
     service.getJobReport("job/1").subscribe((r) => (result = r));
 
@@ -204,7 +246,7 @@ describe("ResultsService", () => {
 
     expect(
       sanitizer.sanitize(SecurityContext.RESOURCE_URL, result as never)
-    ).toBe("about:blank");
+    ).toBe("https://cdn.example.test/report.html");
   });
 
   it("should sanitize report URLs with non-http/https protocol", () => {

--- a/src/app/cores/services/results.service.spec.ts
+++ b/src/app/cores/services/results.service.spec.ts
@@ -110,11 +110,21 @@ describe("ResultsService", () => {
     );
   });
 
-  it("should allow parent-relative preview report URLs", () => {
+  it("should sanitize parent-relative preview report URLs to about:blank", () => {
     const trustedUrl = service.getSafeReportResourceUrl("../report.html");
 
     expect(sanitizer.sanitize(SecurityContext.RESOURCE_URL, trustedUrl)).toBe(
-      `${new URL("../report.html", environment.apiBaseUrl).href}`
+      "about:blank"
+    );
+  });
+
+  it("should sanitize embedded parent traversal segments to about:blank", () => {
+    const trustedUrl = service.getSafeReportResourceUrl(
+      "/reports/../private/report.html"
+    );
+
+    expect(sanitizer.sanitize(SecurityContext.RESOURCE_URL, trustedUrl)).toBe(
+      "about:blank"
     );
   });
 
@@ -123,6 +133,16 @@ describe("ResultsService", () => {
 
     expect(sanitizer.sanitize(SecurityContext.RESOURCE_URL, trustedUrl)).toBe(
       new URL("?token=test-token", apiBase).href
+    );
+  });
+
+  it("should normalize safe relative report paths with duplicate separators", () => {
+    const trustedUrl = service.getSafeReportResourceUrl(
+      "/reports//latest/./index.html?token=test-token#summary"
+    );
+
+    expect(sanitizer.sanitize(SecurityContext.RESOURCE_URL, trustedUrl)).toBe(
+      `${new URL("/reports/latest/index.html", apiBase).href}?token=test-token#summary`
     );
   });
 

--- a/src/app/cores/services/results.service.ts
+++ b/src/app/cores/services/results.service.ts
@@ -75,23 +75,42 @@ export class ResultsService {
     );
   }
 
-  private isAllowedReportUrl(url: string): boolean {
+  private normalizeReportUrl(url: string): string | null {
     try {
-      const base = new URL(environment.apiBaseUrl);
-      const parsed = new URL(url, base);
-      if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
-        return false;
+      const trimmedUrl = url.trim();
+      if (!trimmedUrl) {
+        return null;
       }
-      return parsed.origin === base.origin;
+
+      const base = new URL(environment.apiBaseUrl);
+      const hasExplicitScheme = /^[a-zA-Z][a-zA-Z\d+\-.]*:/.test(trimmedUrl);
+
+      if (hasExplicitScheme) {
+        const parsed = new URL(trimmedUrl);
+        if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+          return null;
+        }
+        return parsed.href;
+      }
+
+      const isRelativePath =
+        trimmedUrl.startsWith("/") ||
+        trimmedUrl.startsWith("./") ||
+        trimmedUrl.startsWith("../") ||
+        trimmedUrl.startsWith("?");
+
+      if (!isRelativePath) {
+        return null;
+      }
+
+      return new URL(trimmedUrl, base).href;
     } catch {
-      return false;
+      return null;
     }
   }
 
   getSafeReportResourceUrl(reportUrl: string): SafeResourceUrl {
-    const safeUrl = this.isAllowedReportUrl(reportUrl)
-      ? reportUrl
-      : "about:blank";
+    const safeUrl = this.normalizeReportUrl(reportUrl) ?? "about:blank";
     return this.sanitizer.bypassSecurityTrustResourceUrl(safeUrl);
   }
 
@@ -103,10 +122,7 @@ export class ResultsService {
           if (!response.report || !response.report.url) {
             return null;
           }
-          const reportUrl = response.report.url.startsWith("http")
-            ? response.report.url
-            : `${environment.apiBaseUrl}${response.report.url}`;
-          return this.getSafeReportResourceUrl(reportUrl);
+          return this.getSafeReportResourceUrl(response.report.url);
         })
       );
   }
@@ -119,10 +135,7 @@ export class ResultsService {
       )
       .pipe(
         map((response) => {
-          const reportUrl = response.url.startsWith("http")
-            ? response.url
-            : `${environment.apiBaseUrl}${response.url}`;
-          return this.getSafeReportResourceUrl(reportUrl);
+          return this.getSafeReportResourceUrl(response.url);
         })
       );
   }

--- a/src/app/cores/services/results.service.ts
+++ b/src/app/cores/services/results.service.ts
@@ -82,19 +82,18 @@ export class ResultsService {
         return null;
       }
 
-      const base = new URL(environment.apiBaseUrl);
       const hasExplicitScheme = /^[a-zA-Z][a-zA-Z\d+\-.]*:/.test(trimmedUrl);
 
       if (hasExplicitScheme) {
         const parsed = new URL(trimmedUrl);
-        if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+        if (parsed.protocol !== "https:") {
           return null;
         }
         return parsed.href;
       }
 
       const isRelativePath =
-        trimmedUrl.startsWith("/") ||
+        (trimmedUrl.startsWith("/") && !trimmedUrl.startsWith("//")) ||
         trimmedUrl.startsWith("./") ||
         trimmedUrl.startsWith("../") ||
         trimmedUrl.startsWith("?");
@@ -103,6 +102,11 @@ export class ResultsService {
         return null;
       }
 
+      const apiBase = environment.apiBaseUrl;
+      if (!apiBase) {
+        return null;
+      }
+      const base = new URL(apiBase.replace(/\/?$/, "/"));
       return new URL(trimmedUrl, base).href;
     } catch {
       return null;

--- a/src/app/cores/services/results.service.ts
+++ b/src/app/cores/services/results.service.ts
@@ -1,6 +1,7 @@
 import { HttpClient } from "@angular/common/http";
 import { inject, Injectable } from "@angular/core";
 import { DomSanitizer, SafeResourceUrl } from "@angular/platform-browser";
+import normalizeUrlPath from "als-normalize-urlpath";
 import { map, Observable } from "rxjs";
 import { environment } from "../../../environments/environment";
 
@@ -75,6 +76,22 @@ export class ResultsService {
     );
   }
 
+  /**
+   * Normalizes report preview URLs into an absolute HTTPS URL that is safe to hand to an iframe.
+   *
+   * Accepted inputs:
+   * - Absolute `https://...` URLs.
+   * - Root-relative paths such as `/api/results/...`.
+   * - Same-directory relative paths that start with `./`.
+   * - Query-only references such as `?token=...`, resolved against `environment.apiBaseUrl`.
+   *
+   * Rejected inputs:
+   * - Empty or whitespace-only strings.
+   * - Protocol-relative URLs such as `//example.test/report`.
+   * - Any explicit non-HTTPS scheme such as `http:`, `javascript:`, `data:`, or `blob:`.
+   * - Parent-directory traversal such as `../report.html` or `/safe/../report.html`.
+   * - Bare host/path values without a scheme, or any other malformed relative reference.
+   */
   private normalizeReportUrl(url: string): string | null {
     try {
       const trimmedUrl = url.trim();
@@ -95,7 +112,6 @@ export class ResultsService {
       const isRelativePath =
         (trimmedUrl.startsWith("/") && !trimmedUrl.startsWith("//")) ||
         trimmedUrl.startsWith("./") ||
-        trimmedUrl.startsWith("../") ||
         trimmedUrl.startsWith("?");
 
       if (!isRelativePath) {
@@ -106,8 +122,31 @@ export class ResultsService {
       if (!apiBase) {
         return null;
       }
+
       const base = new URL(apiBase.replace(/\/?$/, "/"));
-      return new URL(trimmedUrl, base).href;
+      if (trimmedUrl.startsWith("?")) {
+        return new URL(trimmedUrl, base).href;
+      }
+
+      const pathCandidate = trimmedUrl.split(/[?#]/, 1)[0].replace(/\\/g, "/");
+      if (/(^|\/)\.\.(?=\/|$)/.test(pathCandidate)) {
+        return null;
+      }
+
+      const normalized = normalizeUrlPath(trimmedUrl, { encode: true });
+      if (!normalized.pathname) {
+        return null;
+      }
+
+      const resolved = new URL(normalized.pathname, base);
+      if (normalized.query && Object.keys(normalized.query).length > 0) {
+        resolved.search = new URLSearchParams(normalized.query).toString();
+      }
+      if (normalized.hash) {
+        resolved.hash = normalized.hash;
+      }
+
+      return resolved.href;
     } catch {
       return null;
     }

--- a/src/types/als-normalize-urlpath.d.ts
+++ b/src/types/als-normalize-urlpath.d.ts
@@ -1,0 +1,23 @@
+declare module "als-normalize-urlpath" {
+  interface NormalizeUrlPathParams {
+    lower?: boolean;
+    translate?: boolean;
+    slug?: boolean;
+    trim?: boolean;
+    special?: boolean;
+    encode?: boolean;
+  }
+
+  interface NormalizeUrlPathResult {
+    pathname: string | null;
+    query?: Record<string, string>;
+    hash?: string;
+    error?: Error;
+  }
+
+  export default function normalizeUrlPath(
+    urlPath: string,
+    params?: NormalizeUrlPathParams,
+    throwError?: boolean
+  ): NormalizeUrlPathResult;
+}


### PR DESCRIPTION
- [x] Review PR feedback comments
- [x] Fix `results.service.ts`:
  - [x] Reject protocol-relative URLs (`//`) explicitly
  - [x] Move `base` construction into relative URL branch; add explicit null guard for `apiBaseUrl`
  - [x] Normalize base URL with trailing slash (`replace(/\/?$/, "/")`) to avoid path-segment stripping
  - [x] Restrict absolute URLs to `https:` only (remove `http:` allowance)
- [x] Fix `results.service.spec.ts`:
  - [x] Extract shared `apiBase` constant to avoid duplication
  - [x] Fix dot-relative test assertion to use URL constructor via shared `apiBase`
  - [x] Fix query-only test assertion to use URL constructor via shared `apiBase`
  - [x] Add test for protocol-relative URL rejection (`//evil.example/report`)
  - [x] Add test for cross-origin `http:` URL rejection
- [x] Run tests to verify all 20 tests pass