### PR TITLE
feat: inference binder_name from id

### DIFF
--- a/src/app/pages/workflow/de-novo-design/de-novo-design.html
+++ b/src/app/pages/workflow/de-novo-design/de-novo-design.html
@@ -195,8 +195,8 @@
                   <div class="w-full lg:w-1/2 min-w-0 flex flex-col gap-4">
                     @for (field of schemaLoader.requiredInputFields(); track
                     field.name) { @if (field.name === 'starting_pdb' ||
-                    field.name === 'max_length') {
-                    <!-- skip: viewer on left, max_length handled by slider -->
+                    field.name === 'max_length' || field.name === 'binder_name') {
+                    <!-- skip: viewer on left, max_length handled by slider, binder_name derived from id on submit -->
                     } @else if (field.name === 'min_length') {
                     <div class="rounded-lg border border-gray-200 px-4 py-3">
                       <p class="block text-sm font-medium text-gray-700 mb-1">

--- a/src/app/pages/workflow/de-novo-design/de-novo-design.ts
+++ b/src/app/pages/workflow/de-novo-design/de-novo-design.ts
@@ -521,6 +521,7 @@ export class DeNovoDesignComponent implements OnInit, OnDestroy {
           const workflowFormData = {
             ...formData,
             tool: this.selectedToolLabel(),
+            binder_name: (formData["id"] as string) || "",
           };
 
           this.workflowSubmission.submitWorkflowWithDataset(
@@ -666,6 +667,7 @@ export class DeNovoDesignComponent implements OnInit, OnDestroy {
 
     // Validate each required field to show specific errors
     for (const field of requiredFields) {
+      if (field.name === "binder_name") continue;
       const value = currentData[field.name];
       this.validateField(field.name, value);
     }
@@ -680,6 +682,7 @@ export class DeNovoDesignComponent implements OnInit, OnDestroy {
 
     // Check if all required fields have values
     for (const field of requiredFields) {
+      if (field.name === "binder_name") continue;
       const value = currentData[field.name];
       if (value === undefined || value === null || value === "") {
         isValid = false;
@@ -755,7 +758,7 @@ export class DeNovoDesignComponent implements OnInit, OnDestroy {
     }[] = [];
 
     // Fields to exclude from summary
-    const excludedFields = ["settings_filters", "settings_advanced"];
+    const excludedFields = ["settings_filters", "settings_advanced", "binder_name"];
 
     fields.forEach((field) => {
       // Skip excluded fields
@@ -898,6 +901,7 @@ export class DeNovoDesignComponent implements OnInit, OnDestroy {
     // Check each row for required field completeness
     for (const row of rows) {
       for (const field of requiredFields) {
+        if (field.name === "binder_name") continue;
         const value = row.values[field.name];
         if (value === undefined || value === null || value === "") {
           hasErrors = true;


### PR DESCRIPTION
# Pull Request

## Summary
[SBP-298](https://biocloud.atlassian.net/browse/SBP-298)  Remove the redundant **Binder Name** input field from the De Novo Design form. The field is now derived automatically from the **ID** field at submission time, reducing duplication and simplifying the user experience.

## Changes

- **`de-novo-design.html`** — `binder_name` added to the skip list in the required-fields render loop so it is never shown in the form
- **`de-novo-design.ts`** — `binder_name` excluded from `validateAllRequiredFields()`, `validateForm()`, and `validateAllRows()` so the hidden field does not block form validation; `submitWorkflow()` now sets `binder_name` from the `id` field value before dispatching the payload; `binder_name` also excluded from the step 3 review summary

## How to Test

1. Navigate to **De Novo Design → Overview tab**
2. Confirm the **Binder Name** field no longer appears in step 1
3. Fill in the **ID** field and complete the remaining required inputs
4. Submit the workflow and verify the job appears in the jobs list with the correct name (matching the ID value)

Note: As NCI GADI is under maintenance today, demo was using the database params recording instead. Please see the ticket comment for demo record.
[SBP-298](https://biocloud.atlassian.net/browse/SBP-298) 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added or updated documentation where necessary
- [x] I have run linting and unit tests locally
- [x] The code follows the project's style guidelines


[SBP-298]: https://biocloud.atlassian.net/browse/SBP-298?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ