### PR TITLE
Bindcraft

### DIFF
--- a/src/app/pages/workflow/de-novo-design/de-novo-design.html
+++ b/src/app/pages/workflow/de-novo-design/de-novo-design.html
@@ -195,8 +195,8 @@
                   <div class="w-full lg:w-1/2 min-w-0 flex flex-col gap-4">
                     @for (field of schemaLoader.requiredInputFields(); track
                     field.name) { @if (field.name === 'starting_pdb' ||
-                    field.name === 'max_length') {
-                    <!-- skip: viewer on left, max_length handled by slider -->
+                    field.name === 'max_length' || field.name === 'binder_name') {
+                    <!-- skip: viewer on left, max_length handled by slider, binder_name derived from id on submit -->
                     } @else if (field.name === 'min_length') {
                     <div class="rounded-lg border border-gray-200 px-4 py-3">
                       <p class="block text-sm font-medium text-gray-700 mb-1">

--- a/src/app/pages/workflow/de-novo-design/de-novo-design.ts
+++ b/src/app/pages/workflow/de-novo-design/de-novo-design.ts
@@ -521,6 +521,7 @@ export class DeNovoDesignComponent implements OnInit, OnDestroy {
           const workflowFormData = {
             ...formData,
             tool: this.selectedToolLabel(),
+            binder_name: (formData["id"] as string) || "",
           };
 
           this.workflowSubmission.submitWorkflowWithDataset(
@@ -666,6 +667,7 @@ export class DeNovoDesignComponent implements OnInit, OnDestroy {
 
     // Validate each required field to show specific errors
     for (const field of requiredFields) {
+      if (field.name === "binder_name") continue;
       const value = currentData[field.name];
       this.validateField(field.name, value);
     }
@@ -680,6 +682,7 @@ export class DeNovoDesignComponent implements OnInit, OnDestroy {
 
     // Check if all required fields have values
     for (const field of requiredFields) {
+      if (field.name === "binder_name") continue;
       const value = currentData[field.name];
       if (value === undefined || value === null || value === "") {
         isValid = false;
@@ -755,7 +758,7 @@ export class DeNovoDesignComponent implements OnInit, OnDestroy {
     }[] = [];
 
     // Fields to exclude from summary
-    const excludedFields = ["settings_filters", "settings_advanced"];
+    const excludedFields = ["settings_filters", "settings_advanced", "binder_name"];
 
     fields.forEach((field) => {
       // Skip excluded fields
@@ -898,6 +901,7 @@ export class DeNovoDesignComponent implements OnInit, OnDestroy {
     // Check each row for required field completeness
     for (const row of rows) {
       for (const field of requiredFields) {
+        if (field.name === "binder_name") continue;
         const value = row.values[field.name];
         if (value === undefined || value === null || value === "") {
           hasErrors = true;

--- a/src/app/pages/workflow/de-novo-design/de-novo-design.ts
+++ b/src/app/pages/workflow/de-novo-design/de-novo-design.ts
@@ -494,7 +494,11 @@ export class DeNovoDesignComponent implements OnInit, OnDestroy {
       return;
     }
 
-    const formData = this.getFormData();
+    const rawFormData = this.getFormData();
+    const formData = {
+      ...rawFormData,
+      binder_name: (rawFormData["id"] as string) || "",
+    };
 
     console.log("Starting workflow submission with dataset upload...");
 
@@ -521,7 +525,6 @@ export class DeNovoDesignComponent implements OnInit, OnDestroy {
           const workflowFormData = {
             ...formData,
             tool: this.selectedToolLabel(),
-            binder_name: (formData["id"] as string) || "",
           };
 
           this.workflowSubmission.submitWorkflowWithDataset(


### PR DESCRIPTION
The samplesheet CSV is uploaded to Seqera before binder_name is added — so the CSV is missing the required field. The binder_name derivation needs to happen before uploadDataset, not after.

Fixed: update `binder_name` before uploading data sheet