### PR TITLE
feat: enabled signed commits for release-please with github app

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -17,8 +17,8 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v2
         with:
-          app-id: ${{ secrets.AAI_RELEASE_PLEASE_APP_ID }}
-          private-key: ${{ secrets.AAI_RELEASE_PLEASE_APP_PRIVATE_KEY }}
+          app-id: ${{ secrets.SBP_RELEASE_PLEASE_APP_ID }}
+          private-key: ${{ secrets.SBP_RELEASE_PLEASE_APP_PRIVATE_KEY }}
 
       - uses: googleapis/release-please-action@v4
         with:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -13,11 +13,18 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.AAI_RELEASE_PLEASE_APP_ID }}
+          private-key: ${{ secrets.AAI_RELEASE_PLEASE_APP_PRIVATE_KEY }}
+
       - uses: googleapis/release-please-action@v4
         with:
           release-type: node
           package-name: sbp-portal
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
           changelog-types: |
             [
               {"type":"feat","section":"Features","hidden":false},


### PR DESCRIPTION
## Description

Generate github app (https://github.com/organizations/AustralianBioCommons/settings/apps/sbp-release-please) that token for release-please for signed commits.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added unit / integration tests that prove my fix is effective or that my feature works
- [x] I have run all tests locally and they pass
- [x] I have updated the documentation (if applicable)
- [x] For any new secrets, I have updated the [shared spreadsheet](https://docs.google.com/spreadsheets/d/16lGloFh4VxMmu6cJdeFVLy2654hdq-ZeErhB8UifSfI/edit?usp=sharing) and the [GitHub Secrets](https://github.com/AustralianBioCommons/aai-portal/settings/secrets/actions).
