### PR TITLE
SBP-334: Molstar viewer improvement

### DIFF
--- a/src/app/components/workflow/molstar-viewer/molstar-viewer.component.html
+++ b/src/app/components/workflow/molstar-viewer/molstar-viewer.component.html
@@ -19,14 +19,14 @@
     @if (status() === 'loaded') {
     <label
       class="inline-flex items-center gap-1 rounded-md border border-gray-300 bg-white px-3 py-1.5 text-xs font-medium text-gray-600 shadow-sm hover:bg-gray-50"
-      [ngClass]="{ 'cursor-pointer': !disabled, 'opacity-50 pointer-events-none': disabled }"
+      [ngClass]="{ 'cursor-pointer': !disabled(), 'opacity-50 pointer-events-none': disabled() }"
     >
       <svg class="h-3.5 w-3.5 text-gray-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
           d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-8l-4-4m0 0L8 8m4-4v12" />
       </svg>
       Upload new structure
-      <input type="file" class="sr-only" accept=".pdb" [disabled]="disabled" (change)="onFileInputChange($event)" />
+      <input type="file" class="sr-only" accept=".pdb" [disabled]="disabled()" (change)="onFileInputChange($event)" />
     </label>
     }
   </div>
@@ -43,14 +43,14 @@
     </p>
     <label
       class="inline-flex items-center gap-1.5 rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 shadow-sm"
-      [ngClass]="{ 'cursor-pointer': !disabled, 'opacity-50 pointer-events-none': disabled }"
+      [ngClass]="{ 'cursor-pointer': !disabled(), 'opacity-50 pointer-events-none': disabled() }"
     >
       <svg class="h-4 w-4 text-gray-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
           d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-8l-4-4m0 0L8 8m4-4v12" />
       </svg>
       Choose .pdb file
-      <input type="file" class="sr-only" accept=".pdb" [disabled]="disabled" (change)="onFileInputChange($event)" />
+      <input type="file" class="sr-only" accept=".pdb" [disabled]="disabled()" (change)="onFileInputChange($event)" />
     </label>
   </div>
   }

--- a/src/app/components/workflow/molstar-viewer/molstar-viewer.component.ts
+++ b/src/app/components/workflow/molstar-viewer/molstar-viewer.component.ts
@@ -17,7 +17,7 @@ import { Viewer } from "molstar/lib/apps/viewer/app";
 import { PluginUIContext } from "molstar/lib/mol-plugin-ui/context";
 import { StructureSelectionManager } from "molstar/lib/mol-plugin-state/manager/structure/selection";
 import { InteractivityManager } from "molstar/lib/mol-plugin-state/manager/interactivity";
-import { Structure, Unit } from "molstar/lib/mol-model/structure";
+import { StructureElement, Structure, Unit } from "molstar/lib/mol-model/structure";
 import { OrderedSet } from "molstar/lib/mol-data/int";
 
 @Component({
@@ -41,6 +41,17 @@ export class MolstarViewerComponent
   /** Emits total residue count of the loaded structure (use as slider max). */
   @Output() sequenceLengthDetected = new EventEmitter<number>();
 
+  /** Programmatically select residues from outside (e.g. manual form input).
+   *  Accepts the same comma-separated token format the viewer emits:
+   *  "A56,B12" or ranges "A12-A14". Set to "" to clear the selection. */
+  @Input() set externalSelection(value: string) {
+    if (this._externalSelection === value) return;
+    this._externalSelection = value;
+    if (this.status() === "loaded") {
+      this.zone.runOutsideAngular(() => void this.applyExternalSelection(value));
+    }
+  }
+
   readonly status = signal<"idle" | "loading" | "loaded" | "error">("idle");
   readonly errorMessage = signal("");
   readonly selectedResidues = signal<string[]>([]);
@@ -49,6 +60,11 @@ export class MolstarViewerComponent
   private selectionSub: { unsubscribe(): void } | null = null;
   private formSubmitAbortCtrl: AbortController | null = null;
   private readonly zone = inject(NgZone);
+  /** Stores the last value received via [externalSelection] binding. */
+  private _externalSelection = "";
+  /** True while a programmatic selection is being applied — suppresses the
+   *  residuesSelected event so it doesn't echo back to the parent. */
+  private _applyingExternalSelection = false;
 
   private static instanceCount = 0;
   readonly containerId = `molstar-viewer-${++MolstarViewerComponent.instanceCount}`;
@@ -145,6 +161,10 @@ export class MolstarViewerComponent
       this.showSequencePanel();
       this.status.set("loaded");
       this.emitSequenceLength();
+      // Apply any selection that arrived before or while the structure was loading.
+      if (this._externalSelection) {
+        void this.applyExternalSelection(this._externalSelection);
+      }
     } catch (err) {
       this.errorMessage.set(err instanceof Error ? err.message : "Could not render PDB file.");
       this.status.set("error");
@@ -170,6 +190,8 @@ export class MolstarViewerComponent
     try {
       const selMgr = this.selectionManager;
       this.selectionSub = selMgr.events.changed.subscribe(() => {
+        // Suppress echo-back while we are applying an external selection.
+        if (this._applyingExternalSelection) return;
         const residues = this.readCurrentSelection(selMgr);
         const compressed = this.compressToRanges(residues);
         this.zone.run(() => {
@@ -179,6 +201,94 @@ export class MolstarViewerComponent
       });
     } catch {
       console.warn("Mol* selection hook unavailable; hotspot auto-fill disabled.");
+    }
+  }
+
+  /** Programmatically select the residues described by a comma-separated token
+   *  string (e.g. "A56,B12" or ranges "A12-A14").  Suppresses the outgoing
+   *  residuesSelected event so the parent form is not overwritten. */
+  private async applyExternalSelection(residueString: string): Promise<void> {
+    if (!this.plugin || this.status() !== "loaded") return;
+
+    this._applyingExternalSelection = true;
+    try {
+      const lociSelects = this.plugin.managers.interactivity
+        .lociSelects as InteractivityManager.LociSelectManager;
+      lociSelects.deselectAll();
+
+      if (!residueString.trim()) return;
+
+      // Parse tokens → chain → Set<residueNumber>
+      const targetResidues = new Map<string, Set<number>>();
+      for (const token of residueString.split(",").map((t) => t.trim()).filter(Boolean)) {
+        const range = token.match(/^([A-Za-z]+)(\d+)-([A-Za-z]+)(\d+)$/);
+        const single = !range && token.match(/^([A-Za-z]+)(-?\d+)$/);
+        if (range && range[1] === range[3]) {
+          const chain = range[1];
+          const lo = Math.min(parseInt(range[2]), parseInt(range[4]));
+          const hi = Math.max(parseInt(range[2]), parseInt(range[4]));
+          if (!targetResidues.has(chain)) targetResidues.set(chain, new Set());
+          for (let i = lo; i <= hi; i++) targetResidues.get(chain)!.add(i);
+        } else if (single) {
+          const chain = single[1];
+          const resNum = parseInt(single[2]);
+          if (!targetResidues.has(chain)) targetResidues.set(chain, new Set());
+          targetResidues.get(chain)!.add(resNum);
+        }
+      }
+      if (targetResidues.size === 0) return;
+
+      // Walk loaded structures and build StructureElement.Loci for matching atoms.
+      const structures =
+        this.plugin.managers.structure.hierarchy.current?.structures ?? [];
+      for (const s of structures) {
+        const structure = s.cell.obj?.data as Structure | undefined;
+        if (!structure) continue;
+
+        const elementGroups: { unit: Unit; indices: number[] }[] = [];
+
+        for (const unit of structure.units) {
+          if (!Unit.isAtomic(unit)) continue;
+          try {
+            const { atomicHierarchy } = unit.model;
+            const residueIdx = atomicHierarchy.residueAtomSegments.index;
+            const chainIdx = atomicHierarchy.chainAtomSegments.index;
+            const seqIdVal = atomicHierarchy.residues.auth_seq_id.value;
+            const chainIdVal = atomicHierarchy.chains.auth_asym_id.value;
+
+            const matchingUnitIndices: number[] = [];
+            // Second arg to forEach is the unit-local index (UnitIndex).
+            OrderedSet.forEach(unit.elements, (elemIdx: number, unitIdx: number) => {
+              const chain = chainIdVal(chainIdx[elemIdx]);
+              const resNum = seqIdVal(residueIdx[elemIdx]);
+              if (targetResidues.get(chain)?.has(resNum)) {
+                matchingUnitIndices.push(unitIdx);
+              }
+            });
+
+            if (matchingUnitIndices.length > 0) {
+              elementGroups.push({ unit, indices: matchingUnitIndices });
+            }
+          } catch { /* skip unit */ }
+        }
+
+        if (elementGroups.length === 0) continue;
+
+        const elements = elementGroups.map(({ unit, indices }) => ({
+          unit,
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          indices: OrderedSet.ofSortedArray(new Int32Array(indices.sort((a, b) => a - b)) as any) as any,
+        }));
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const loci = StructureElement.Loci(structure, elements as any);
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        this.selectionManager.fromLoci("add", loci as any);
+      }
+    } catch (e) {
+      console.warn("Mol* external selection failed:", e);
+    } finally {
+      // Allow selection events to drain before re-enabling the hook.
+      setTimeout(() => { this._applyingExternalSelection = false; }, 120);
     }
   }
 

--- a/src/app/components/workflow/molstar-viewer/molstar-viewer.component.ts
+++ b/src/app/components/workflow/molstar-viewer/molstar-viewer.component.ts
@@ -1,16 +1,15 @@
 import {
   AfterViewInit,
   Component,
-  EventEmitter,
-  Input,
   NgZone,
-  OnChanges,
   OnDestroy,
-  Output,
-  SimpleChanges,
   ViewEncapsulation,
+  effect,
   inject,
-  signal
+  input,
+  output,
+  signal,
+  untracked,
 } from "@angular/core";
 import { CommonModule } from "@angular/common";
 import { Viewer } from "molstar/lib/apps/viewer/app";
@@ -30,32 +29,24 @@ import { OrderedSet } from "molstar/lib/mol-data/int";
   templateUrl: "./molstar-viewer.component.html",
   host: { class: "block" },
 })
-export class MolstarViewerComponent
-  implements AfterViewInit, OnChanges, OnDestroy
-{
-  @Input() pdbFile: File | null = null;
-  /** Emits a comma-separated residue string (e.g. "A42,A43,B11") on each selection change. */
-  @Output() residuesSelected = new EventEmitter<string>();
+export class MolstarViewerComponent implements AfterViewInit, OnDestroy {
+  pdbFile = input<File | null>(null);
   /** Disables the file picker embedded in the idle placeholder. */
-  @Input() disabled = false;
-  /** Emits the chosen File when the user picks one from the idle placeholder. */
-  @Output() filePicked = new EventEmitter<File>();
-  /** Emits total residue count of the loaded structure (use as slider max). */
-  @Output() sequenceLengthDetected = new EventEmitter<number>();
-  /** Emits the full chain→residue-number map after a structure loads.
-   *  The parent can use this for validation without re-parsing the PDB file. */
-  @Output() structureResiduesDetected = new EventEmitter<Map<string, Set<number>>>();
-
+  disabled = input(false);
   /** Programmatically select residues from outside (e.g. manual form input).
    *  Accepts the same comma-separated token format the viewer emits:
    *  "A56,B12" or ranges "A12-A14". Set to "" to clear the selection. */
-  @Input() set externalSelection(value: string) {
-    if (this._externalSelection === value) return;
-    this._externalSelection = value;
-    if (this.status() === "loaded") {
-      this.zone.runOutsideAngular(() => void this.applyExternalSelection(value));
-    }
-  }
+  externalSelection = input("");
+
+  /** Emits a comma-separated residue string (e.g. "A42,A43,B11") on each selection change. */
+  residuesSelected = output<string>();
+  /** Emits the chosen File when the user picks one from the idle placeholder. */
+  filePicked = output<File>();
+  /** Emits total residue count of the loaded structure (use as slider max). */
+  sequenceLengthDetected = output<number>();
+  /** Emits the full chain→residue-number map after a structure loads.
+   *  The parent can use this for validation without re-parsing the PDB file. */
+  structureResiduesDetected = output<Map<string, Set<number>>>();
 
   readonly status = signal<"idle" | "loading" | "loaded" | "error">("idle");
   readonly errorMessage = signal("");
@@ -65,14 +56,36 @@ export class MolstarViewerComponent
   private selectionSub: { unsubscribe(): void } | null = null;
   private formSubmitAbortCtrl: AbortController | null = null;
   private readonly zone = inject(NgZone);
-  /** Stores the last value received via [externalSelection] binding. */
-  private _externalSelection = "";
   /** True while a programmatic selection is being applied — suppresses the
    *  residuesSelected event so it doesn't echo back to the parent. */
   private _applyingExternalSelection = false;
+  private _viewInitialized = false;
 
   private static instanceCount = 0;
   readonly containerId = `molstar-viewer-${++MolstarViewerComponent.instanceCount}`;
+
+  constructor() {
+    // Replaces ngOnChanges: react to pdbFile changes after view is ready.
+    effect(() => {
+      const file = this.pdbFile();
+      untracked(() => {
+        if (!this._viewInitialized) return;
+        if (file) void this.loadFile(file);
+        else this.clearViewer();
+      });
+    });
+
+    // Replaces the externalSelection setter.
+    effect(() => {
+      const sel = this.externalSelection();
+      untracked(() => {
+        if (!this._viewInitialized) return;
+        if (this.status() === "loaded") {
+          this.zone.runOutsideAngular(() => void this.applyExternalSelection(sel));
+        }
+      });
+    });
+  }
 
   // ── File input (idle placeholder) ────────────────────────────────────────
 
@@ -89,18 +102,9 @@ export class MolstarViewerComponent
   // ── Lifecycle ─────────────────────────────────────────────────────────────
 
   ngAfterViewInit(): void {
-    if (this.pdbFile) {
-      void this.loadFile(this.pdbFile);
-    }
-  }
-
-  ngOnChanges(changes: SimpleChanges): void {
-    if (!changes["pdbFile"] || changes["pdbFile"].isFirstChange()) return;
-    if (this.pdbFile) {
-      void this.loadFile(this.pdbFile);
-    } else {
-      this.clearViewer();
-    }
+    this._viewInitialized = true;
+    const file = this.pdbFile();
+    if (file) void this.loadFile(file);
   }
 
   ngOnDestroy(): void {
@@ -167,8 +171,9 @@ export class MolstarViewerComponent
       this.status.set("loaded");
       this.emitStructureInfo();
       // Apply any selection that arrived before or while the structure was loading.
-      if (this._externalSelection) {
-        void this.applyExternalSelection(this._externalSelection);
+      const pendingSel = this.externalSelection();
+      if (pendingSel) {
+        void this.applyExternalSelection(pendingSel);
       }
     } catch (err) {
       this.errorMessage.set(err instanceof Error ? err.message : "Could not render PDB file.");

--- a/src/app/components/workflow/molstar-viewer/molstar-viewer.component.ts
+++ b/src/app/components/workflow/molstar-viewer/molstar-viewer.component.ts
@@ -226,20 +226,10 @@ export class MolstarViewerComponent
       // Parse tokens → chain → Set<residueNumber>
       const targetResidues = new Map<string, Set<number>>();
       for (const token of residueString.split(",").map((t) => t.trim()).filter(Boolean)) {
-        const range = token.match(/^([A-Za-z]+)(\d+)-([A-Za-z]+)(\d+)$/);
-        const single = !range && token.match(/^([A-Za-z]+)(-?\d+)$/);
-        if (range && range[1] === range[3]) {
-          const chain = range[1];
-          const lo = Math.min(parseInt(range[2]), parseInt(range[4]));
-          const hi = Math.max(parseInt(range[2]), parseInt(range[4]));
-          if (!targetResidues.has(chain)) targetResidues.set(chain, new Set());
-          for (let i = lo; i <= hi; i++) targetResidues.get(chain)!.add(i);
-        } else if (single) {
-          const chain = single[1];
-          const resNum = parseInt(single[2]);
-          if (!targetResidues.has(chain)) targetResidues.set(chain, new Set());
-          targetResidues.get(chain)!.add(resNum);
-        }
+        const parsed = MolstarViewerComponent.parseResidueToken(token);
+        if (!parsed) continue;
+        if (!targetResidues.has(parsed.chain)) targetResidues.set(parsed.chain, new Set());
+        for (let i = parsed.resStart; i <= parsed.resEnd; i++) targetResidues.get(parsed.chain)!.add(i);
       }
       if (targetResidues.size === 0) return;
 
@@ -450,6 +440,22 @@ export class MolstarViewerComponent
   private cleanupSubscription(): void {
     this.selectionSub?.unsubscribe();
     this.selectionSub = null;
+  }
+
+  /** Parse a residue token ("A56" or same-chain range "A12-A14") into
+   *  { chain, resStart, resEnd }, or null for an unrecognised format. */
+  static parseResidueToken(token: string): { chain: string; resStart: number; resEnd: number } | null {
+    const range = token.match(/^([A-Za-z]+)(\d+)-([A-Za-z]+)(\d+)$/);
+    if (range) {
+      if (range[1] !== range[3]) return null;
+      return { chain: range[1], resStart: parseInt(range[2], 10), resEnd: parseInt(range[4], 10) };
+    }
+    const single = token.match(/^([A-Za-z]+)(-?\d+)$/);
+    if (single) {
+      const n = parseInt(single[2], 10);
+      return { chain: single[1], resStart: n, resEnd: n };
+    }
+    return null;
   }
 
   private parseResidueLabel(label: string): { chain: string; seq: number } | null {

--- a/src/app/components/workflow/molstar-viewer/molstar-viewer.component.ts
+++ b/src/app/components/workflow/molstar-viewer/molstar-viewer.component.ts
@@ -17,7 +17,9 @@ import { Viewer } from "molstar/lib/apps/viewer/app";
 import { PluginUIContext } from "molstar/lib/mol-plugin-ui/context";
 import { StructureSelectionManager } from "molstar/lib/mol-plugin-state/manager/structure/selection";
 import { InteractivityManager } from "molstar/lib/mol-plugin-state/manager/interactivity";
-import { StructureElement, Structure, Unit } from "molstar/lib/mol-model/structure";
+import { StructureSelection, QueryContext, Structure, Unit } from "molstar/lib/mol-model/structure";
+import { MolScriptBuilder as MS } from "molstar/lib/mol-script/language/builder";
+import { compile } from "molstar/lib/mol-script/runtime/query/compiler";
 import { OrderedSet } from "molstar/lib/mol-data/int";
 
 @Component({
@@ -40,6 +42,9 @@ export class MolstarViewerComponent
   @Output() filePicked = new EventEmitter<File>();
   /** Emits total residue count of the loaded structure (use as slider max). */
   @Output() sequenceLengthDetected = new EventEmitter<number>();
+  /** Emits the full chain→residue-number map after a structure loads.
+   *  The parent can use this for validation without re-parsing the PDB file. */
+  @Output() structureResiduesDetected = new EventEmitter<Map<string, Set<number>>>();
 
   /** Programmatically select residues from outside (e.g. manual form input).
    *  Accepts the same comma-separated token format the viewer emits:
@@ -160,7 +165,7 @@ export class MolstarViewerComponent
       await this.applyBallAndStick();
       this.showSequencePanel();
       this.status.set("loaded");
-      this.emitSequenceLength();
+      this.emitStructureInfo();
       // Apply any selection that arrived before or while the structure was loading.
       if (this._externalSelection) {
         void this.applyExternalSelection(this._externalSelection);
@@ -238,56 +243,36 @@ export class MolstarViewerComponent
       }
       if (targetResidues.size === 0) return;
 
-      // Walk loaded structures and build StructureElement.Loci for matching atoms.
+      // Build one MolScript atomGroups expression per chain, then merge.
+      const chainExprs = Array.from(targetResidues.entries()).map(([chain, residues]) =>
+        MS.struct.generator.atomGroups({
+          "chain-test": MS.core.rel.eq([MS.ammp("auth_asym_id"), chain]),
+          "residue-test": MS.core.set.has([
+            MS.set(...Array.from(residues)),
+            MS.ammp("auth_seq_id"),
+          ]),
+        })
+      );
+      const expr =
+        chainExprs.length === 1
+          ? chainExprs[0]
+          : MS.struct.combinator.merge(chainExprs);
+      const query = compile<StructureSelection>(expr);
+
+      // Run the query against every loaded structure and apply the result.
       const structures =
         this.plugin.managers.structure.hierarchy.current?.structures ?? [];
       for (const s of structures) {
         const structure = s.cell.obj?.data as Structure | undefined;
         if (!structure) continue;
-
-        const elementGroups: { unit: Unit; indices: number[] }[] = [];
-
-        for (const unit of structure.units) {
-          if (!Unit.isAtomic(unit)) continue;
-          try {
-            const { atomicHierarchy } = unit.model;
-            const residueIdx = atomicHierarchy.residueAtomSegments.index;
-            const chainIdx = atomicHierarchy.chainAtomSegments.index;
-            const seqIdVal = atomicHierarchy.residues.auth_seq_id.value;
-            const chainIdVal = atomicHierarchy.chains.auth_asym_id.value;
-
-            const matchingUnitIndices: number[] = [];
-            // Second arg to forEach is the unit-local index (UnitIndex).
-            OrderedSet.forEach(unit.elements, (elemIdx: number, unitIdx: number) => {
-              const chain = chainIdVal(chainIdx[elemIdx]);
-              const resNum = seqIdVal(residueIdx[elemIdx]);
-              if (targetResidues.get(chain)?.has(resNum)) {
-                matchingUnitIndices.push(unitIdx);
-              }
-            });
-
-            if (matchingUnitIndices.length > 0) {
-              elementGroups.push({ unit, indices: matchingUnitIndices });
-            }
-          } catch { /* skip unit */ }
-        }
-
-        if (elementGroups.length === 0) continue;
-
-        const elements = elementGroups.map(({ unit, indices }) => ({
-          unit,
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          indices: OrderedSet.ofSortedArray(new Int32Array(indices.sort((a, b) => a - b)) as any) as any,
-        }));
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const loci = StructureElement.Loci(structure, elements as any);
+        const sel = query(new QueryContext(structure));
+        const loci = StructureSelection.toLociWithSourceUnits(sel);
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         this.selectionManager.fromLoci("add", loci as any);
       }
     } catch (e) {
       console.warn("Mol* external selection failed:", e);
     } finally {
-      // Allow selection events to drain before re-enabling the hook.
       setTimeout(() => { this._applyingExternalSelection = false; }, 120);
     }
   }
@@ -370,11 +355,12 @@ export class MolstarViewerComponent
     } catch { /* non-critical — default visual still shows */ }
   }
 
-  /** Count unique residues and emit for any consumers that want a sequence length. */
-  private emitSequenceLength(): void {
+  /** Walk the loaded structure once, then emit the chain→residue map and total
+   *  residue count.  Replaces separate emitSequenceLength + parsePdbResidues. */
+  private emitStructureInfo(): void {
     try {
       const structures = this.plugin?.managers.structure.hierarchy.current?.structures ?? [];
-      const residuesSeen = new Set<string>();
+      const residueMap = new Map<string, Set<number>>();
 
       for (const s of structures) {
         const structure = s.cell.obj?.data as Structure | undefined;
@@ -388,14 +374,21 @@ export class MolstarViewerComponent
             const seqIdVal = atomicHierarchy.residues.auth_seq_id.value;
             const chainIdVal = atomicHierarchy.chains.auth_asym_id.value;
             OrderedSet.forEach(unit.elements, (atomIdx) => {
-              residuesSeen.add(`${chainIdVal(chainIdx[atomIdx])}_${seqIdVal(residueIdx[atomIdx])}`);
+              const chain = chainIdVal(chainIdx[atomIdx]);
+              const resNum = seqIdVal(residueIdx[atomIdx]);
+              if (!residueMap.has(chain)) residueMap.set(chain, new Set());
+              residueMap.get(chain)!.add(resNum);
             });
           } catch { /* skip unit */ }
         }
       }
 
-      if (residuesSeen.size > 0) {
-        this.zone.run(() => this.sequenceLengthDetected.emit(residuesSeen.size));
+      if (residueMap.size > 0) {
+        const total = [...residueMap.values()].reduce((n, s) => n + s.size, 0);
+        this.zone.run(() => {
+          this.structureResiduesDetected.emit(residueMap);
+          this.sequenceLengthDetected.emit(total);
+        });
       }
     } catch { /* non-critical */ }
   }

--- a/src/app/pages/workflow/de-novo-design/de-novo-design.html
+++ b/src/app/pages/workflow/de-novo-design/de-novo-design.html
@@ -162,11 +162,13 @@
                       }
                     </div>
 
-                    @if (hasRowFieldError(row.id, 'starting_pdb') &&
-                    !localPdbFile()) {
-                    <p class="px-4 pt-2 text-sm text-red-600">
-                      {{ getRowFieldError(row.id, 'starting_pdb') }}
-                    </p>
+                    @if (hasRowFieldError(row.id, 'starting_pdb')) {
+                    <div class="mx-4 mt-2 flex items-start gap-2 rounded-md border border-amber-200 bg-amber-50 px-4 py-3">
+                      <svg class="mt-0.5 h-4 w-4 shrink-0 text-amber-500" viewBox="0 0 20 20" fill="currentColor">
+                        <path fill-rule="evenodd" d="M8.485 2.495c.673-1.167 2.357-1.167 3.03 0l6.28 10.875c.673 1.167-.17 2.625-1.516 2.625H3.72c-1.347 0-2.189-1.458-1.515-2.625L8.485 2.495zM10 5a.75.75 0 01.75.75v3.5a.75.75 0 01-1.5 0v-3.5A.75.75 0 0110 5zm0 9a1 1 0 100-2 1 1 0 000 2z" clip-rule="evenodd" />
+                      </svg>
+                      <p class="text-sm text-red-600">{{ getRowFieldError(row.id, 'starting_pdb') }}</p>
+                    </div>
                     }
 
                     <div class="p-4">
@@ -327,7 +329,7 @@
               type="button"
               variant="primary"
               (click)="submitWorkflow()"
-              [disabled]="(auth.isAuthenticated$ | async) === false"
+              [disabled]="!isFormValid() || (auth.isAuthenticated$ | async) === false"
               borderRadius="rounded-[10px]"
               colorClasses="px-4 py-2 border border-gray-300 text-white bg-teal-500 hover:opacity-90 disabled:opacity-60 hover:bg-teal-400 disabled:cursor-not-allowed">
               Submit

--- a/src/app/pages/workflow/de-novo-design/de-novo-design.html
+++ b/src/app/pages/workflow/de-novo-design/de-novo-design.html
@@ -173,6 +173,7 @@
                       <app-molstar-viewer
                         [pdbFile]="localPdbFile()"
                         [disabled]="isPdbUploading()"
+                        [externalSelection]="programmaticViewerSelection()"
                         (filePicked)="onPdbFilePicked($event, row.id)"
                         (residuesSelected)="onResiduesSelected(row.id, $event)"
                         (sequenceLengthDetected)="onSequenceLengthDetected($event)"></app-molstar-viewer>
@@ -199,6 +200,14 @@
                         [disabled]="isPdbUploading()"
                         (rangeChange)="onLengthRangeChange(row.id, $event)"></app-length-range-slider>
                     </div>
+                    } @else if (field.name === 'target_hotspot_residues') {
+                    <app-form-field
+                      [field]="field"
+                      [value]="getRowValue(row.id, field.name)"
+                      [hasError]="hasRowFieldError(row.id, field.name)"
+                      [errorMessage]="getRowFieldError(row.id, field.name) || ''"
+                      (valueChange)="onHotspotResiduesManualChange(row.id, $event)"
+                      (fieldBlur)="validateRowField(row.id, field.name)"></app-form-field>
                     } @else {
                     <app-form-field
                       [field]="field"

--- a/src/app/pages/workflow/de-novo-design/de-novo-design.html
+++ b/src/app/pages/workflow/de-novo-design/de-novo-design.html
@@ -176,6 +176,7 @@
                         [externalSelection]="programmaticViewerSelection()"
                         (filePicked)="onPdbFilePicked($event, row.id)"
                         (residuesSelected)="onResiduesSelected(row.id, $event)"
+                        (structureResiduesDetected)="onStructureResiduesDetected($event)"
                         (sequenceLengthDetected)="onSequenceLengthDetected($event)"></app-molstar-viewer>
                     </div>
                   </div>

--- a/src/app/pages/workflow/de-novo-design/de-novo-design.ts
+++ b/src/app/pages/workflow/de-novo-design/de-novo-design.ts
@@ -317,8 +317,21 @@ export class DeNovoDesignComponent implements OnInit, OnDestroy {
     this.updateRowValueWithValidation(rowId, "chains", chains);
   }
 
-  onSequenceLengthDetected(_: number): void {
-    // Slider bound and min/max values stay at schema defaults regardless of PDB length.
+  onSequenceLengthDetected(count: number): void {
+    const rowId = this.schemaLoader.inputRows()[0]?.id;
+    if (!rowId) return;
+    const errorKey = `${rowId}_starting_pdb`;
+    const currentErrors = this.formErrors();
+    if (count < 50) {
+      this.formErrors.set({ ...currentErrors, [errorKey]: `Structure has only ${count} residue(s). Minimum 50 residues required.` });
+    } else if (count > 300) {
+      this.formErrors.set({ ...currentErrors, [errorKey]: `Structure has ${count} residues. Maximum 300 residues allowed.` });
+    } else {
+      const updated = { ...currentErrors };
+      delete updated[errorKey];
+      this.formErrors.set(updated);
+    }
+    this.validateAllRows();
   }
 
   onLengthRangeChange(

--- a/src/app/pages/workflow/de-novo-design/de-novo-design.ts
+++ b/src/app/pages/workflow/de-novo-design/de-novo-design.ts
@@ -241,15 +241,8 @@ export class DeNovoDesignComponent implements OnInit, OnDestroy {
     this.pdbResidueMap.set(residues.size > 0 ? residues : null);
   }
 
-  /** Validate the Chains field value.
-   *  Rules:
-   *  1. Each token must be letters only (e.g. "A", "AB").
-   *  2. If a PDB is loaded, each token must be a known chain.
-   *  3. Every chain letter used in target_hotspot_residues must appear here.
-   *  Returns an error string, or null if valid. */
   private validateChains(rowId: string, value: string): string | null {
-    if (!value || !value.trim()) return null;
-
+    if (!value?.trim()) return null;
     const tokens = value.split(",").map((t) => t.trim()).filter(Boolean);
 
     for (const token of tokens) {
@@ -262,13 +255,11 @@ export class DeNovoDesignComponent implements OnInit, OnDestroy {
     if (residueMap) {
       for (const token of tokens) {
         if (!residueMap.has(token)) {
-          const available = [...residueMap.keys()].sort().join(", ");
-          return `Chain "${token}" not found in PDB. Available chains: ${available}.`;
+          return `Chain "${token}" not found in PDB. Available: ${[...residueMap.keys()].sort().join(", ")}.`;
         }
       }
     }
 
-    // Every chain letter that appears in hotspot residues must be listed here.
     const hotspot = (this.getRowValue(rowId, "target_hotspot_residues") as string) ?? "";
     if (hotspot.trim()) {
       const chainsSet = new Set(tokens);
@@ -278,63 +269,31 @@ export class DeNovoDesignComponent implements OnInit, OnDestroy {
         }
       }
     }
-
     return null;
   }
 
-  /** Validate hotspot residue tokens against PDB chain/residue data.
-   *  Returns an error string, or null if valid. */
   private validateHotspotResidues(value: string): string | null {
-    if (!value || !value.trim()) return null;
-
-    const tokens = value.split(",").map((t) => t.trim()).filter(Boolean);
+    if (!value?.trim()) return null;
     const residueMap = this.pdbResidueMap();
 
-    for (const token of tokens) {
-      // Range: A12-A14
-      const rangeMatch = token.match(/^([A-Za-z]+)(\d+)-([A-Za-z]+)(\d+)$/);
-      // Single: A56 or A-5
-      const singleMatch = !rangeMatch && token.match(/^([A-Za-z]+)(-?\d+)$/);
-
-      if (!rangeMatch && !singleMatch) {
+    for (const token of value.split(",").map((t) => t.trim()).filter(Boolean)) {
+      const parsed = MolstarViewerComponent.parseResidueToken(token);
+      if (!parsed) {
         return `Invalid format "${token}". Use chain+residue notation, e.g. "A56" or "A12-A14".`;
       }
+      if (!residueMap) continue;
 
-      if (residueMap) {
-        if (singleMatch) {
-          const chain = singleMatch[1];
-          const resNum = parseInt(singleMatch[2], 10);
-          const chainResidues = residueMap.get(chain);
-          if (!chainResidues) {
-            const available = [...residueMap.keys()].sort().join(", ");
-            return `Chain "${chain}" not found in PDB. Available chains: ${available}.`;
-          }
-          if (!chainResidues.has(resNum)) {
-            return `Residue ${resNum} not found in chain "${chain}" of the PDB file.`;
-          }
-        } else if (rangeMatch) {
-          const chainStart = rangeMatch[1];
-          const resStart = parseInt(rangeMatch[2], 10);
-          const chainEnd = rangeMatch[3];
-          const resEnd = parseInt(rangeMatch[4], 10);
-          if (chainStart !== chainEnd) {
-            return `Range "${token}" spans different chains; use single-chain ranges like "A12-A14".`;
-          }
-          const chainResidues = residueMap.get(chainStart);
-          if (!chainResidues) {
-            const available = [...residueMap.keys()].sort().join(", ");
-            return `Chain "${chainStart}" not found in PDB. Available chains: ${available}.`;
-          }
-          if (!chainResidues.has(resStart)) {
-            return `Start residue ${resStart} not found in chain "${chainStart}" of the PDB file.`;
-          }
-          if (!chainResidues.has(resEnd)) {
-            return `End residue ${resEnd} not found in chain "${chainStart}" of the PDB file.`;
-          }
-        }
+      const chainResidues = residueMap.get(parsed.chain);
+      if (!chainResidues) {
+        return `Chain "${parsed.chain}" not found in PDB. Available: ${[...residueMap.keys()].sort().join(", ")}.`;
+      }
+      if (!chainResidues.has(parsed.resStart)) {
+        return `Residue ${parsed.resStart} not found in chain "${parsed.chain}".`;
+      }
+      if (parsed.resStart !== parsed.resEnd && !chainResidues.has(parsed.resEnd)) {
+        return `End residue ${parsed.resEnd} not found in chain "${parsed.chain}".`;
       }
     }
-
     return null;
   }
 

--- a/src/app/pages/workflow/de-novo-design/de-novo-design.ts
+++ b/src/app/pages/workflow/de-novo-design/de-novo-design.ts
@@ -209,8 +209,6 @@ export class DeNovoDesignComponent implements OnInit, OnDestroy {
     this.uploadedPdbFile.set(null);
     // Use filename as placeholder value so schema required-check passes.
     this.updateRowValueWithValidation(rowId, "starting_pdb", file.name);
-    // Parse PDB residues for manual-entry validation (async, non-blocking).
-    void this.parsePdbResidues(file);
   }
 
   clearLocalPdb(rowId: string): void {
@@ -237,28 +235,10 @@ export class DeNovoDesignComponent implements OnInit, OnDestroy {
       .join(",");
   }
 
-  /** Parse ATOM/HETATM records from the PDB file to build a chain→residue map
-   *  used for validating manually entered hotspot residues. */
-  private async parsePdbResidues(file: File): Promise<void> {
-    try {
-      const text = await file.text();
-      const residueMap = new Map<string, Set<number>>();
-      for (const line of text.split("\n")) {
-        const recordType = line.substring(0, 6).trim();
-        if (recordType !== "ATOM" && recordType !== "HETATM") continue;
-        if (line.length < 26) continue;
-        const chain = line[21];
-        const resNum = parseInt(line.substring(22, 26).trim(), 10);
-        if (!chain || !chain.trim() || isNaN(resNum)) continue;
-        const key = chain.trim();
-        if (!residueMap.has(key)) residueMap.set(key, new Set());
-        residueMap.get(key)!.add(resNum);
-      }
-      this.pdbResidueMap.set(residueMap.size > 0 ? residueMap : null);
-    } catch {
-      // Non-critical: PDB-based validation is skipped when parsing fails.
-      this.pdbResidueMap.set(null);
-    }
+  /** Receives the chain→residue map emitted by the Mol* viewer after it
+   *  parses the PDB structure — no need to re-parse the file ourselves. */
+  onStructureResiduesDetected(residues: Map<string, Set<number>>): void {
+    this.pdbResidueMap.set(residues.size > 0 ? residues : null);
   }
 
   /** Validate the Chains field value.

--- a/src/app/pages/workflow/de-novo-design/de-novo-design.ts
+++ b/src/app/pages/workflow/de-novo-design/de-novo-design.ts
@@ -172,6 +172,10 @@ export class DeNovoDesignComponent implements OnInit, OnDestroy {
    *  Actual upload to S3 is deferred until the user clicks Next. */
   localPdbFile = signal<File | null>(null);
 
+  /** Parsed chain → residue-number set from the loaded PDB.  Populated
+   *  asynchronously after the user picks a file; null until then. */
+  pdbResidueMap = signal<Map<string, Set<number>> | null>(null);
+
   /** Reference to the File object that was last successfully uploaded.
    *  Used to skip re-upload when the user navigates Back then Next again. */
   private uploadedPdbFile = signal<File | null>(null);
@@ -198,20 +202,176 @@ export class DeNovoDesignComponent implements OnInit, OnDestroy {
     if (this.localPdbFile()) {
       this.updateRowValue(rowId, "chains", "");
       this.updateRowValue(rowId, "target_hotspot_residues", "");
+      this.programmaticViewerSelection.set("");
     }
     this.localPdbFile.set(file);
     // New file picked — reset upload tracking so Next will upload this file.
     this.uploadedPdbFile.set(null);
     // Use filename as placeholder value so schema required-check passes.
     this.updateRowValueWithValidation(rowId, "starting_pdb", file.name);
+    // Parse PDB residues for manual-entry validation (async, non-blocking).
+    void this.parsePdbResidues(file);
   }
 
   clearLocalPdb(rowId: string): void {
     this.localPdbFile.set(null);
     this.uploadedPdbFile.set(null);
+    this.pdbResidueMap.set(null);
+    this.programmaticViewerSelection.set("");
     this.updateRowValueWithValidation(rowId, "starting_pdb", "");
     this.updateRowValueWithValidation(rowId, "chains", "");
     this.updateRowValueWithValidation(rowId, "target_hotspot_residues", "");
+  }
+
+  /** Return sorted, deduplicated chain letters from a residue string like "A56,B12-B20". */
+  private chainsFromResidues(residues: string): string {
+    return [
+      ...new Set(
+        residues
+          .split(",")
+          .map((r) => r.trim().match(/^([A-Za-z]+)/)?.[1] ?? "")
+          .filter(Boolean),
+      ),
+    ]
+      .sort()
+      .join(",");
+  }
+
+  /** Parse ATOM/HETATM records from the PDB file to build a chain→residue map
+   *  used for validating manually entered hotspot residues. */
+  private async parsePdbResidues(file: File): Promise<void> {
+    try {
+      const text = await file.text();
+      const residueMap = new Map<string, Set<number>>();
+      for (const line of text.split("\n")) {
+        const recordType = line.substring(0, 6).trim();
+        if (recordType !== "ATOM" && recordType !== "HETATM") continue;
+        if (line.length < 26) continue;
+        const chain = line[21];
+        const resNum = parseInt(line.substring(22, 26).trim(), 10);
+        if (!chain || !chain.trim() || isNaN(resNum)) continue;
+        const key = chain.trim();
+        if (!residueMap.has(key)) residueMap.set(key, new Set());
+        residueMap.get(key)!.add(resNum);
+      }
+      this.pdbResidueMap.set(residueMap.size > 0 ? residueMap : null);
+    } catch {
+      // Non-critical: PDB-based validation is skipped when parsing fails.
+      this.pdbResidueMap.set(null);
+    }
+  }
+
+  /** Validate the Chains field value.
+   *  Rules:
+   *  1. Each token must be letters only (e.g. "A", "AB").
+   *  2. If a PDB is loaded, each token must be a known chain.
+   *  3. Every chain letter used in target_hotspot_residues must appear here.
+   *  Returns an error string, or null if valid. */
+  private validateChains(rowId: string, value: string): string | null {
+    if (!value || !value.trim()) return null;
+
+    const tokens = value.split(",").map((t) => t.trim()).filter(Boolean);
+
+    for (const token of tokens) {
+      if (!/^[A-Za-z]+$/.test(token)) {
+        return `Invalid chain "${token}". Use letter identifiers only, e.g. "A" or "A,B".`;
+      }
+    }
+
+    const residueMap = this.pdbResidueMap();
+    if (residueMap) {
+      for (const token of tokens) {
+        if (!residueMap.has(token)) {
+          const available = [...residueMap.keys()].sort().join(", ");
+          return `Chain "${token}" not found in PDB. Available chains: ${available}.`;
+        }
+      }
+    }
+
+    // Every chain letter that appears in hotspot residues must be listed here.
+    const hotspot = (this.getRowValue(rowId, "target_hotspot_residues") as string) ?? "";
+    if (hotspot.trim()) {
+      const chainsSet = new Set(tokens);
+      for (const hChain of this.chainsFromResidues(hotspot).split(",").filter(Boolean)) {
+        if (!chainsSet.has(hChain)) {
+          return `Chain "${hChain}" is used in Target Hotspot Residues but not listed in Chains.`;
+        }
+      }
+    }
+
+    return null;
+  }
+
+  /** Validate hotspot residue tokens against PDB chain/residue data.
+   *  Returns an error string, or null if valid. */
+  private validateHotspotResidues(value: string): string | null {
+    if (!value || !value.trim()) return null;
+
+    const tokens = value.split(",").map((t) => t.trim()).filter(Boolean);
+    const residueMap = this.pdbResidueMap();
+
+    for (const token of tokens) {
+      // Range: A12-A14
+      const rangeMatch = token.match(/^([A-Za-z]+)(\d+)-([A-Za-z]+)(\d+)$/);
+      // Single: A56 or A-5
+      const singleMatch = !rangeMatch && token.match(/^([A-Za-z]+)(-?\d+)$/);
+
+      if (!rangeMatch && !singleMatch) {
+        return `Invalid format "${token}". Use chain+residue notation, e.g. "A56" or "A12-A14".`;
+      }
+
+      if (residueMap) {
+        if (singleMatch) {
+          const chain = singleMatch[1];
+          const resNum = parseInt(singleMatch[2], 10);
+          const chainResidues = residueMap.get(chain);
+          if (!chainResidues) {
+            const available = [...residueMap.keys()].sort().join(", ");
+            return `Chain "${chain}" not found in PDB. Available chains: ${available}.`;
+          }
+          if (!chainResidues.has(resNum)) {
+            return `Residue ${resNum} not found in chain "${chain}" of the PDB file.`;
+          }
+        } else if (rangeMatch) {
+          const chainStart = rangeMatch[1];
+          const resStart = parseInt(rangeMatch[2], 10);
+          const chainEnd = rangeMatch[3];
+          const resEnd = parseInt(rangeMatch[4], 10);
+          if (chainStart !== chainEnd) {
+            return `Range "${token}" spans different chains; use single-chain ranges like "A12-A14".`;
+          }
+          const chainResidues = residueMap.get(chainStart);
+          if (!chainResidues) {
+            const available = [...residueMap.keys()].sort().join(", ");
+            return `Chain "${chainStart}" not found in PDB. Available chains: ${available}.`;
+          }
+          if (!chainResidues.has(resStart)) {
+            return `Start residue ${resStart} not found in chain "${chainStart}" of the PDB file.`;
+          }
+          if (!chainResidues.has(resEnd)) {
+            return `End residue ${resEnd} not found in chain "${chainStart}" of the PDB file.`;
+          }
+        }
+      }
+    }
+
+    return null;
+  }
+
+  /** Drives the [externalSelection] input on the Mol* viewer.  Only updated
+   *  by manual form input — never by viewer-originated selection — so there
+   *  is no circular feedback loop. */
+  programmaticViewerSelection = signal<string>("");
+
+  /** Called when the user manually edits the target_hotspot_residues field.
+   *  Updates the value, auto-derives chains, validates against the PDB, and
+   *  pushes the new selection string to the Mol* viewer. */
+  onHotspotResiduesManualChange(rowId: string, value: unknown): void {
+    const residues = (value as string) ?? "";
+    this.updateRowValueWithValidation(rowId, "target_hotspot_residues", residues);
+    const chains = this.chainsFromResidues(residues);
+    if (chains) this.updateRowValueWithValidation(rowId, "chains", chains);
+    this.programmaticViewerSelection.set(residues);
   }
 
   onChainsDetected(rowId: string, chains: string): void {
@@ -235,28 +395,9 @@ export class DeNovoDesignComponent implements OnInit, OnDestroy {
    *  and auto-fills the chains field. e.g. "A56,B12" → chains = "A,B".
    */
   onResiduesSelected(rowId: string, residues: string): void {
-    if (residues) {
-      this.updateRowValueWithValidation(
-        rowId,
-        "target_hotspot_residues",
-        residues,
-      );
-      // Derive chains from the leading letter(s) of each residue token
-      const chains = [
-        ...new Set(
-          residues
-            .split(",")
-            .map((r) => r.trim().match(/^([A-Za-z]+)/)?.[1] ?? "")
-            .filter(Boolean),
-        ),
-      ]
-        .sort()
-        .join(",");
-      if (chains) this.updateRowValueWithValidation(rowId, "chains", chains);
-    } else {
-      this.updateRowValueWithValidation(rowId, "target_hotspot_residues", "");
-      this.updateRowValueWithValidation(rowId, "chains", "");
-    }
+    this.updateRowValueWithValidation(rowId, "target_hotspot_residues", residues);
+    const chains = this.chainsFromResidues(residues);
+    this.updateRowValueWithValidation(rowId, "chains", chains);
   }
 
   // Steps marked complete only when user presses Next on that step
@@ -332,6 +473,11 @@ export class DeNovoDesignComponent implements OnInit, OnDestroy {
     if (current === 1) {
       this.attemptedStep1.set(true);
       this.validateAllRequiredFields();
+      // Ensure row-level validation (including PDB-based hotspot checks) runs.
+      for (const row of this.schemaLoader.inputRows()) {
+        this.validateRowField(row.id, "target_hotspot_residues");
+        this.validateRowField(row.id, "chains");
+      }
       this.validateForm();
 
       if (!this.isFormValid()) {
@@ -895,6 +1041,18 @@ export class DeNovoDesignComponent implements OnInit, OnDestroy {
     const currentErrors = this.formErrors();
 
     if (validationResult.valid) {
+      // Custom field-level validators (PDB-aware).
+      let customError: string | null = null;
+      if (fieldName === "target_hotspot_residues") {
+        customError = this.validateHotspotResidues(value as string);
+      } else if (fieldName === "chains") {
+        customError = this.validateChains(rowId, value as string);
+      }
+      if (customError) {
+        this.formErrors.set({ ...currentErrors, [errorKey]: customError });
+        this.validateAllRows();
+        return;
+      }
       // Remove error for this specific cell
       const updatedErrors = { ...currentErrors };
       delete updatedErrors[errorKey];

--- a/src/app/pages/workflow/de-novo-design/de-novo-design.ts
+++ b/src/app/pages/workflow/de-novo-design/de-novo-design.ts
@@ -338,48 +338,6 @@ export class DeNovoDesignComponent implements OnInit, OnDestroy {
         console.log("Cannot proceed: Input configuration validation failed");
         return;
       }
-
-      // Upload the PDB file to S3 before moving on, if one is pending.
-      const file = this.localPdbFile();
-      const rowId = this.schemaLoader.inputRows()[0]?.id;
-      if (file && rowId && file !== this.uploadedPdbFile()) {
-        this.isPdbUploading.set(true);
-        this.subscription.add(
-          this.pdbUploadService
-            .uploadPdbFile({
-              file,
-              metadata: {
-                fieldName: "starting_pdb",
-                uploadedAt: new Date().toISOString(),
-              },
-            })
-            .subscribe({
-              next: (response) => {
-                const s3Uri =
-                  response.s3Uri ??
-                  response.fileUrl ??
-                  response.fileId ??
-                  response.fileName ??
-                  file.name;
-                // Replace placeholder filename with the real S3 path.
-                this.updateRowValueWithValidation(rowId, "starting_pdb", s3Uri);
-                // Record the uploaded file so Back+Next doesn't re-upload it.
-                this.uploadedPdbFile.set(file);
-                this.isPdbUploading.set(false);
-                this.advanceStep(current);
-              },
-              error: (error) => {
-                this.isPdbUploading.set(false);
-                const msg =
-                  error?.error?.message ?? error?.message ?? "Unknown error";
-                this.showError(
-                  `Failed to upload PDB file: ${msg}. Please try again.`,
-                );
-              },
-            }),
-        );
-        return;
-      }
     }
 
     this.advanceStep(current);
@@ -500,6 +458,52 @@ export class DeNovoDesignComponent implements OnInit, OnDestroy {
       return;
     }
 
+    const file = this.localPdbFile();
+    const rowId = this.schemaLoader.inputRows()[0]?.id;
+
+    if (file && rowId && file !== this.uploadedPdbFile()) {
+      this.isPdbUploading.set(true);
+      this.workflowSubmission.isSubmitting.set(true);
+      this.subscription.add(
+        this.pdbUploadService
+          .uploadPdbFile({
+            file,
+            metadata: {
+              fieldName: "starting_pdb",
+              uploadedAt: new Date().toISOString(),
+            },
+          })
+          .subscribe({
+            next: (response) => {
+              const s3Uri =
+                response.s3Uri ??
+                response.fileUrl ??
+                response.fileId ??
+                response.fileName ??
+                file.name;
+              this.updateRowValueWithValidation(rowId, "starting_pdb", s3Uri);
+              this.uploadedPdbFile.set(file);
+              this.isPdbUploading.set(false);
+              this.doSubmitWorkflow();
+            },
+            error: (error) => {
+              this.isPdbUploading.set(false);
+              this.workflowSubmission.isSubmitting.set(false);
+              const msg =
+                error?.error?.message ?? error?.message ?? "Unknown error";
+              this.showError(
+                `Failed to upload PDB file: ${msg}. Please try again.`,
+              );
+            },
+          }),
+      );
+      return;
+    }
+
+    this.doSubmitWorkflow();
+  }
+
+  private doSubmitWorkflow(): void {
     const rawFormData = this.getFormData();
     const formData = {
       ...rawFormData,


### PR DESCRIPTION
<!--
Thank you for contributing! Please fill out the sections below to help maintainers review your change faster.
Delete any sections that don't apply.
-->

# Pull Request

## Summary
[SBP-334](https://biocloud.atlassian.net/browse/SBP-334) Implements bidirectional sync between the Mol* 3D viewer and the `target_hotspot_residues` text input in the De Novo Design workflow. Previously only viewer → form was supported (clicking residues in 3D populated the field); now manual edits in the form field also drive selection highlights in the viewer. Also adds PDB-aware validation for `chains` and `target_hotspot_residues` fields.

## Changes
- **`molstar-viewer.component.ts`** — Added `@Input() externalSelection` to accept programmatic residue selection from a parent; added `@Output() structureResiduesDetected` to emit the full chain→residue map after a structure loads; added `applyExternalSelection()` using MolScript queries; suppresses echo-back events via `_applyingExternalSelection` flag; refactored `emitSequenceLength()` → `emitStructureInfo()` (single structure pass emits both outputs); added static `parseResidueToken()` utility.
- **`de-novo-design.ts`** — Added `pdbResidueMap` signal (populated from `structureResiduesDetected`); added `programmaticViewerSelection` signal bound to viewer's `[externalSelection]`; added `onHotspotResiduesManualChange()` that updates value, auto-derives chains, and pushes selection to viewer; added `validateChains()` and `validateHotspotResidues()` with PDB-aware validation (unknown chains/residues produce inline errors); moved PDB S3 upload from the "Next" step to submit (`doSubmitWorkflow()`); simplified `onResiduesSelected()` using shared `chainsFromResidues()`.
- **`de-novo-design.html`** — Wired new `[externalSelection]` and `(structureResiduesDetected)` bindings; added dedicated `@else if` branch for `target_hotspot_residues` with `(valueChange)="onHotspotResiduesManualChange()"`.
- No breaking changes or migrations required.

## How to Test
1. Open the De Novo Design workflow and reach Step 1 (Input Configuration).
2. Upload a PDB file — the 3D viewer loads and the sequence length slider populates as before.
3. Click residues in the Mol* viewer → `target_hotspot_residues` and `chains` fields auto-fill (existing behaviour).
4. Manually type a valid residue string (e.g. `A56,A57`) into `target_hotspot_residues` → the Mol* viewer highlights those residues.
5. Type an invalid chain (e.g. `Z99`) → expect an inline error: `Chain "Z" not found in PDB. Available: A, B, …`.
6. Type a chain in `chains` that doesn't match a hotspot residue → expect a cross-field validation error.
7. Click Next without a PDB → form still requires `starting_pdb` (no regression).
8. Fill all fields and submit → PDB upload occurs at submission time, not on Next.

## Demo
Demo video is available at the ticket comment [here](https://biocloud.atlassian.net/browse/SBP-334?focusedCommentId=27883)

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added or updated documentation where necessary
- [ ] I have run linting and unit tests locally
- [ ] The code follows the project's style guidelines


[SBP-334]: https://biocloud.atlassian.net/browse/SBP-334?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ