### PR TITLE
fix: add runtime config to manage secrets properly

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ npm test
 
 Notes:
 
-- Environment variables are hardcoded in `src/environments/environment.ts` for local development. Update that file if you need to point to a different backend.
+- Runtime config is loaded from `src/assets/config/app-config.json` and merged with defaults from `src/environments/environment.ts`, matching the AAI portal pattern. Update `app-config.json` for local runtime config changes.
 - Tailwind and PostCSS are configured via `tailwind.config.cjs` and `postcss.config.cjs`.
 - If you scaffolded with a different version of Angular CLI locally, some generated files may differ; these files are a minimal starting point created without running the Angular CLI in this environment.
 

--- a/src/app/cores/config/runtime-config-loader.service.ts
+++ b/src/app/cores/config/runtime-config-loader.service.ts
@@ -1,0 +1,52 @@
+import { HttpClient } from "@angular/common/http";
+import { Injectable, inject } from "@angular/core";
+import { AuthClientConfig } from "@auth0/auth0-angular";
+import { firstValueFrom, of } from "rxjs";
+import { catchError, tap } from "rxjs/operators";
+import {
+  environmentDefaults,
+  updateEnvironment,
+} from "../../../environments/environment";
+import {
+  RuntimeEnvironmentConfig,
+  mergeEnvironmentConfig,
+} from "../../../environments/runtime-config";
+
+@Injectable({ providedIn: "root" })
+export class RuntimeConfigLoaderService {
+  private readonly http = inject(HttpClient);
+  private readonly authClientConfig = inject(AuthClientConfig);
+
+  load(): Promise<RuntimeEnvironmentConfig> {
+    return firstValueFrom(
+      this.http
+        .get<RuntimeEnvironmentConfig>("assets/config/app-config.json")
+        .pipe(
+          catchError((error) => {
+            console.error(
+              "Failed to load runtime config. Using defaults.",
+              error
+            );
+            return of({} as RuntimeEnvironmentConfig);
+          }),
+          tap((runtime) => {
+            updateEnvironment(runtime);
+            const merged = mergeEnvironmentConfig(environmentDefaults, runtime);
+            const apiBaseUrl = merged.apiBaseUrl || window.location.origin;
+
+            this.authClientConfig.set({
+              domain: merged.auth.domain,
+              clientId: merged.auth.clientId,
+              authorizationParams: {
+                audience: merged.auth.audience,
+                redirect_uri: window.location.origin,
+              },
+              httpInterceptor: {
+                allowedList: [`${apiBaseUrl}/api/*`],
+              },
+            });
+          })
+        )
+    ).catch(() => ({} as RuntimeEnvironmentConfig));
+  }
+}

--- a/src/assets/config/app-config.json
+++ b/src/assets/config/app-config.json
@@ -1,0 +1,12 @@
+{
+  "production": false,
+  "auth": {
+    "domain": "dev.login.aai.test.biocommons.org.au",
+    "clientId": "VgTSGK8Ph92r8mVhmVvQDrxGzbWX0vCm",
+    "audience": "https://dev.api.aai.test.biocommons.org.au"
+  },
+  "apiBaseUrl": "https://api.dev.sbp.test.biocommons.org.au",
+  "profileUrl": "https://dev.portal.aai.test.biocommons.org.au/profile",
+  "rolesClaim": "https://biocommons.org.au/roles",
+  "workflowRole": "biocommons/group/sbp_workflow_execution"
+}

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -1,6 +1,10 @@
 import { Environment } from "./environment.interface";
+import {
+  RuntimeEnvironmentConfig,
+  mergeEnvironmentConfig,
+} from "./runtime-config";
 
-export const environment: Environment = {
+const defaults: Environment = {
   production: true,
   auth: {
     domain: "dev.login.aai.test.biocommons.org.au",
@@ -12,3 +16,17 @@ export const environment: Environment = {
   rolesClaim: "https://biocommons.org.au/roles",
   workflowRole: "biocommons/group/sbp_workflow_execution",
 };
+
+export const environment: Environment = mergeEnvironmentConfig(defaults);
+
+export function updateEnvironment(runtime?: RuntimeEnvironmentConfig): void {
+  const merged = mergeEnvironmentConfig(defaults, runtime);
+  environment.production = merged.production;
+  environment.auth = merged.auth;
+  environment.apiBaseUrl = merged.apiBaseUrl;
+  environment.profileUrl = merged.profileUrl;
+  environment.rolesClaim = merged.rolesClaim;
+  environment.workflowRole = merged.workflowRole;
+}
+
+export const environmentDefaults = defaults;

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -7,14 +7,14 @@ import {
 const defaults: Environment = {
   production: true,
   auth: {
-    domain: "dev.login.aai.test.biocommons.org.au",
-    clientId: "VgTSGK8Ph92r8mVhmVvQDrxGzbWX0vCm",
-    audience: "https://dev.api.aai.test.biocommons.org.au",
+    domain: "",
+    clientId: "",
+    audience: "",
   },
-  apiBaseUrl: "https://api.dev.sbp.test.biocommons.org.au",
-  profileUrl: "https://dev.portal.aai.test.biocommons.org.au/profile",
-  rolesClaim: "https://biocommons.org.au/roles",
-  workflowRole: "biocommons/group/sbp_workflow_execution",
+  apiBaseUrl: "",
+  profileUrl: "",
+  rolesClaim: "",
+  workflowRole: "",
 };
 
 export const environment: Environment = mergeEnvironmentConfig(defaults);

--- a/src/environments/environment.spec.ts
+++ b/src/environments/environment.spec.ts
@@ -1,0 +1,64 @@
+import {
+  environment,
+  environmentDefaults,
+  updateEnvironment,
+} from "./environment";
+
+describe("environment", () => {
+  afterEach(() => {
+    updateEnvironment();
+  });
+
+  it("exports defaults matching environmentDefaults", () => {
+    expect(environment.production).toBe(environmentDefaults.production);
+    expect(environment.auth).toEqual(environmentDefaults.auth);
+    expect(environment.apiBaseUrl).toBe(environmentDefaults.apiBaseUrl);
+    expect(environment.profileUrl).toBe(environmentDefaults.profileUrl);
+    expect(environment.rolesClaim).toBe(environmentDefaults.rolesClaim);
+    expect(environment.workflowRole).toBe(environmentDefaults.workflowRole);
+  });
+
+  describe("updateEnvironment", () => {
+    it("overrides all fields from runtime config", () => {
+      updateEnvironment({
+        production: true,
+        auth: {
+          domain: "staging.login.example.com",
+          clientId: "staging-client",
+        },
+        apiBaseUrl: "https://api.staging.example.com",
+        profileUrl: "https://staging.portal.example.com/profile",
+        rolesClaim: "https://example.com/roles",
+        workflowRole: "example/group/workflow",
+      });
+
+      expect(environment.production).toBe(true);
+      expect(environment.auth.domain).toBe("staging.login.example.com");
+      expect(environment.auth.clientId).toBe("staging-client");
+      expect(environment.apiBaseUrl).toBe("https://api.staging.example.com");
+      expect(environment.profileUrl).toBe(
+        "https://staging.portal.example.com/profile"
+      );
+      expect(environment.rolesClaim).toBe("https://example.com/roles");
+      expect(environment.workflowRole).toBe("example/group/workflow");
+    });
+
+    it("merges partial auth override while keeping unspecified auth fields", () => {
+      updateEnvironment({ auth: { domain: "other.login.example.com" } });
+
+      expect(environment.auth.domain).toBe("other.login.example.com");
+      expect(environment.auth.clientId).toBe(environmentDefaults.auth.clientId);
+    });
+
+    it("restores defaults when called with no argument", () => {
+      updateEnvironment({
+        production: true,
+        apiBaseUrl: "https://other.example.com",
+      });
+      updateEnvironment();
+
+      expect(environment.production).toBe(environmentDefaults.production);
+      expect(environment.apiBaseUrl).toBe(environmentDefaults.apiBaseUrl);
+    });
+  });
+});

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -1,6 +1,10 @@
 import { Environment } from "./environment.interface";
+import {
+  RuntimeEnvironmentConfig,
+  mergeEnvironmentConfig,
+} from "./runtime-config";
 
-export const environment: Environment = {
+const defaults: Environment = {
   production: false,
   auth: {
     domain: "dev.login.aai.test.biocommons.org.au",
@@ -12,3 +16,17 @@ export const environment: Environment = {
   rolesClaim: "https://biocommons.org.au/roles",
   workflowRole: "biocommons/group/sbp_workflow_execution",
 };
+
+export const environment: Environment = mergeEnvironmentConfig(defaults);
+
+export function updateEnvironment(runtime?: RuntimeEnvironmentConfig): void {
+  const merged = mergeEnvironmentConfig(defaults, runtime);
+  environment.production = merged.production;
+  environment.auth = merged.auth;
+  environment.apiBaseUrl = merged.apiBaseUrl;
+  environment.profileUrl = merged.profileUrl;
+  environment.rolesClaim = merged.rolesClaim;
+  environment.workflowRole = merged.workflowRole;
+}
+
+export const environmentDefaults = defaults;

--- a/src/environments/runtime-config.ts
+++ b/src/environments/runtime-config.ts
@@ -1,0 +1,24 @@
+import { Environment } from "./environment.interface";
+
+export interface RuntimeEnvironmentConfig {
+  production?: boolean;
+  auth?: Partial<Environment["auth"]>;
+  apiBaseUrl?: string;
+  profileUrl?: string;
+  rolesClaim?: string;
+  workflowRole?: string;
+}
+
+export function mergeEnvironmentConfig(
+  defaults: Environment,
+  runtime?: RuntimeEnvironmentConfig
+): Environment {
+  return {
+    ...defaults,
+    ...(runtime ?? {}),
+    auth: {
+      ...defaults.auth,
+      ...(runtime?.auth ?? {}),
+    },
+  };
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,10 +1,12 @@
 // src/main.ts
+import { inject, provideAppInitializer } from "@angular/core";
 import { provideHttpClient, withInterceptors } from "@angular/common/http";
 import { bootstrapApplication } from "@angular/platform-browser";
 import { provideAnimations } from "@angular/platform-browser/animations";
 import { provideRouter } from "@angular/router";
 import { authHttpInterceptorFn, provideAuth0 } from "@auth0/auth0-angular";
 import { AppComponent } from "./app/app.component";
+import { RuntimeConfigLoaderService } from "./app/cores/config/runtime-config-loader.service";
 import { authGuard } from "./app/cores/auth.guard";
 import { Home } from "./app/pages/home/home";
 import { JobsComponent } from "./app/pages/jobs/jobs";
@@ -42,6 +44,7 @@ bootstrapApplication(AppComponent, {
       // 404 catch-all route - MUST be last
       { path: "**", component: NotFoundComponent },
     ]),
+    provideAppInitializer(() => inject(RuntimeConfigLoaderService).load()),
     provideAuth0({
       domain: environment.auth.domain,
       clientId: environment.auth.clientId,


### PR DESCRIPTION
<!--
Thank you for contributing! Please fill out the sections below to help maintainers review your change faster.
Delete any sections that don't apply.
-->

# Pull Request

## Summary

[SBP-383](https://biocloud.atlassian.net/browse/SBP-383): manage secrets and variables better. We now load `assets/config/app-config.json` at startup, merges it into environment, and updates Auth0 config before the app runs. 

The release Lambda now reads the frontend secret and writes those values into deployed `assets/config/app-config.json` (similar to [what we have in aai-portal](https://github.com/AustralianBioCommons/aai-portal/blob/main/src/assets/config/app-config.json)).

See related pull requests:
- https://github.com/AustralianBioCommons/sbp-backend/pull/44
- https://github.com/AustralianBioCommons/sbp-infrastructure/pull/5


## Changes

- Add `RuntimeConfigLoaderService` that fetches `assets/config/app-config.json` at app startup and configures Auth0 dynamically — allows the CDK release deployer Lambda to inject environment-specific values without a rebuild
- Add `runtime-config.ts` with typed `RuntimeEnvironmentConfig` interface and merge logic
- Add `app-config.json` with dev defaults
- Update `environment.ts/environment.prod.ts` to support runtime overrides via `updateEnvironment()`

## How to Test

All tests in CI shall pass

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added or updated documentation where necessary
- [x] I have run linting and unit tests locally
- [x] The code follows the project's style guidelines


[SBP-383]: https://biocloud.atlassian.net/browse/SBP-383?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ