### PR TITLE
fix: fetch runtime config before bootstrap so Auth0 uses correct domain/clientId

### DIFF
--- a/src/assets/config/app-config.json
+++ b/src/assets/config/app-config.json
@@ -1,12 +1,12 @@
 {
   "production": false,
   "auth": {
-    "domain": "dev.login.aai.test.biocommons.org.au",
-    "clientId": "VgTSGK8Ph92r8mVhmVvQDrxGzbWX0vCm",
-    "audience": "https://dev.api.aai.test.biocommons.org.au"
+    "domain": "staging.login.aai.test.biocommons.org.au",
+    "clientId": "2vbDXDDwrNLig1AbGADJHNn6GqitsCSo",
+    "audience": "https://staging.api.aai.test.biocommons.org.au"
   },
-  "apiBaseUrl": "https://api.dev.sbp.test.biocommons.org.au",
-  "profileUrl": "https://dev.portal.aai.test.biocommons.org.au/profile",
+  "apiBaseUrl": "https://api.staging.sbp.test.biocommons.org.au",
+  "profileUrl": "https://staging.portal.aai.test.biocommons.org.au/profile",
   "rolesClaim": "https://biocommons.org.au/roles",
   "workflowRole": "biocommons/group/sbp_workflow_execution"
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,13 +1,11 @@
-import { provideZoneChangeDetection } from "@angular/core";
 // src/main.ts
-import { inject, provideAppInitializer } from "@angular/core";
+import { provideZoneChangeDetection } from "@angular/core";
 import { provideHttpClient, withInterceptors } from "@angular/common/http";
 import { bootstrapApplication } from "@angular/platform-browser";
 import { provideAnimations } from "@angular/platform-browser/animations";
 import { provideRouter } from "@angular/router";
 import { authHttpInterceptorFn, provideAuth0 } from "@auth0/auth0-angular";
 import { AppComponent } from "./app/app.component";
-import { RuntimeConfigLoaderService } from "./app/cores/config/runtime-config-loader.service";
 import { authGuard } from "./app/cores/auth.guard";
 import { Home } from "./app/pages/home/home";
 import { JobsComponent } from "./app/pages/jobs/jobs";
@@ -16,55 +14,74 @@ import { NotFoundComponent } from "./app/pages/not-found/not-found";
 import { DeNovoDesignComponent } from "./app/pages/workflow/de-novo-design/de-novo-design";
 import { InteractionScreeningComponent } from "./app/pages/workflow/interaction-screening/interaction-screening";
 import { SinglePredictionComponent } from "./app/pages/workflow/single-prediction/single-prediction";
-import { environment } from "./environments/environment";
+import {
+  environmentDefaults,
+  updateEnvironment,
+} from "./environments/environment";
+import {
+  RuntimeEnvironmentConfig,
+  mergeEnvironmentConfig,
+} from "./environments/runtime-config";
 
-bootstrapApplication(AppComponent, {
-  providers: [
-    provideZoneChangeDetection(),
-    provideAnimations(),
-    provideRouter([
-      { path: "", redirectTo: "/themes", pathMatch: "full" },
-      { path: "themes", component: Home },
-      {
-        path: "de-novo-design",
-        component: DeNovoDesignComponent,
-      },
-      {
-        path: "interaction-screening",
-        component: InteractionScreeningComponent,
-      },
-      {
-        path: "single-structure-prediction",
-        component: SinglePredictionComponent,
-      },
-      {
-        path: "jobs",
-        component: JobsComponent,
-      },
-      { path: "protected", component: AppComponent, canActivate: [authGuard] },
-      { path: "dev/access-preview", component: AccessPreviewComponent },
-      // 404 catch-all route - MUST be last
-      { path: "**", component: NotFoundComponent },
-    ]),
-    provideAppInitializer(() => inject(RuntimeConfigLoaderService).load()),
-    provideAuth0({
-      domain: environment.auth.domain,
-      clientId: environment.auth.clientId,
-      authorizationParams: {
-        audience: environment.auth.audience,
-        redirect_uri: window.location.origin,
-      },
-      // Configure Auth0's built-in interceptor
-      httpInterceptor: {
-        allowedList: [
-          // If apiBaseUrl is configured, use it; otherwise use relative paths pattern
-          environment.apiBaseUrl
-            ? `${environment.apiBaseUrl}/api/*`
-            : `${window.location.origin}/api/*`,
-        ],
-      },
-    }),
-    // Use Auth0's built-in HTTP interceptor instead of our custom one
-    provideHttpClient(withInterceptors([authHttpInterceptorFn])),
-  ],
-}).catch((err) => console.error(err));
+async function bootstrap(): Promise<void> {
+  let runtimeConfig: RuntimeEnvironmentConfig = {};
+  try {
+    const response = await fetch("assets/config/app-config.json");
+    runtimeConfig = await response.json();
+  } catch {
+    console.warn("Failed to load runtime config, using defaults.");
+  }
+
+  updateEnvironment(runtimeConfig);
+  const config = mergeEnvironmentConfig(environmentDefaults, runtimeConfig);
+  const apiBaseUrl = config.apiBaseUrl || window.location.origin;
+
+  bootstrapApplication(AppComponent, {
+    providers: [
+      provideZoneChangeDetection(),
+      provideAnimations(),
+      provideRouter([
+        { path: "", redirectTo: "/themes", pathMatch: "full" },
+        { path: "themes", component: Home },
+        {
+          path: "de-novo-design",
+          component: DeNovoDesignComponent,
+        },
+        {
+          path: "interaction-screening",
+          component: InteractionScreeningComponent,
+        },
+        {
+          path: "single-structure-prediction",
+          component: SinglePredictionComponent,
+        },
+        {
+          path: "jobs",
+          component: JobsComponent,
+        },
+        {
+          path: "protected",
+          component: AppComponent,
+          canActivate: [authGuard],
+        },
+        { path: "dev/access-preview", component: AccessPreviewComponent },
+        // 404 catch-all route - MUST be last
+        { path: "**", component: NotFoundComponent },
+      ]),
+      provideAuth0({
+        domain: config.auth.domain,
+        clientId: config.auth.clientId,
+        authorizationParams: {
+          audience: config.auth.audience,
+          redirect_uri: window.location.origin,
+        },
+        httpInterceptor: {
+          allowedList: [`${apiBaseUrl}/api/*`],
+        },
+      }),
+      provideHttpClient(withInterceptors([authHttpInterceptorFn])),
+    ],
+  }).catch((err) => console.error(err));
+}
+
+bootstrap();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,11 +8,17 @@
     "declaration": false,
     "experimentalDecorators": true,
     "module": "es2020",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "importHelpers": true,
     "target": "es2022",
     "types": ["jasmine", "node"],
     "typeRoots": ["node_modules/@types"],
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "paths": {
+      "@auth0/auth0-angular/public-api": [
+        "node_modules/@auth0/auth0-angular/public-api"
+      ],
+      "@auth0/auth0-angular/lib/*": ["node_modules/@auth0/auth0-angular/lib/*"]
+    }
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,7 @@
     "declaration": false,
     "experimentalDecorators": true,
     "module": "es2020",
-    "moduleResolution": "bundler",
+    "moduleResolution": "node",
     "importHelpers": true,
     "target": "es2022",
     "types": ["jasmine", "node"],


### PR DESCRIPTION
<!--
Thank you for contributing! Please fill out the sections below to help maintainers review your change faster.
Delete any sections that don't apply.
-->

# Pull Request

## Summary

Fix Auth0 initialisation using runtime config

Auth0 was always initialising with the compiled-in dev credentials because `provideAuth0()` ran synchronously before the `APP_INITIALIZER` could call `authClientConfig.set()`.


## Changes

Fixed by fetching app-config.json with native fetch before bootstrapping and passing the runtime values directly to provideAuth0().

Also fixes a pre-existing build failure caused by moduleResolution: "bundler" being incompatible with @auth0/auth0-angular's re-export chain — changed to "node".


## How to Test

https://github.com/user-attachments/assets/2192bbaf-055c-4a93-8e2c-db2e836464f3



## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added or updated documentation where necessary
- [x] I have run linting and unit tests locally
- [x] The code follows the project's style guidelines
