### PR TITLE
Sbp 364 dataset

### DIFF
--- a/.github/workflows/ci-deploy.yml
+++ b/.github/workflows/ci-deploy.yml
@@ -39,9 +39,10 @@ jobs:
         uses: actions/download-artifact@v8
         with:
           name: dist
+          path: dist
 
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./dist/sbp-portal
+          publish_dir: ./dist/sbp-portal/browser

--- a/src/app/cores/services/dataset-upload.service.spec.ts
+++ b/src/app/cores/services/dataset-upload.service.spec.ts
@@ -55,4 +55,32 @@ describe("DatasetUploadService", () => {
       datasetId: "dataset-123",
     });
   });
+
+  it("should upload interaction screening dataset to the correct endpoint", () => {
+    const requestBody = {
+      sequences: [
+        { id: "querySeq1", group: "query" as const },
+        { id: "targetSeq1", group: "target" as const },
+      ],
+      runId: "my-run",
+    };
+
+    service
+      .uploadInteractionScreeningDataset(requestBody)
+      .subscribe((response) => {
+        expect(response.success).toBeTrue();
+        expect(response.datasetId).toBe("dataset-456");
+      });
+
+    const req = httpMock.expectOne(
+      `${environment.apiBaseUrl}/api/workflows/datasets/interaction-screening/upload`
+    );
+    expect(req.request.method).toBe("POST");
+    expect(req.request.body).toEqual(requestBody);
+    req.flush({
+      success: true,
+      message: "uploaded",
+      datasetId: "dataset-456",
+    });
+  });
 });

--- a/src/app/cores/services/dataset-upload.service.ts
+++ b/src/app/cores/services/dataset-upload.service.ts
@@ -16,6 +16,13 @@ export interface DatasetUploadResponse {
   details?: unknown;
 }
 
+export interface InteractionScreeningDatasetUploadRequest {
+  sequences: { id: string; group: "query" | "target" }[];
+  runId: string;
+  datasetName?: string;
+  datasetDescription?: string;
+}
+
 @Injectable({
   providedIn: "root",
 })
@@ -23,14 +30,20 @@ export class DatasetUploadService {
   private http = inject(HttpClient);
   private readonly apiUrl = `${environment.apiBaseUrl}/api/workflows/datasets`;
 
-  /**
-   * Upload dataset to the Seqera Platform via backend API
-   */
   uploadDataset(
     request: DatasetUploadRequest
   ): Observable<DatasetUploadResponse> {
     return this.http.post<DatasetUploadResponse>(
       `${this.apiUrl}/upload`,
+      request
+    );
+  }
+
+  uploadInteractionScreeningDataset(
+    request: InteractionScreeningDatasetUploadRequest
+  ): Observable<DatasetUploadResponse> {
+    return this.http.post<DatasetUploadResponse>(
+      `${this.apiUrl}/interaction-screening/upload`,
       request
     );
   }

--- a/src/app/cores/services/dataset-upload.service.ts
+++ b/src/app/cores/services/dataset-upload.service.ts
@@ -19,8 +19,6 @@ export interface DatasetUploadResponse {
 export interface InteractionScreeningDatasetUploadRequest {
   sequences: { id: string; group: "query" | "target" }[];
   runId: string;
-  datasetName?: string;
-  datasetDescription?: string;
 }
 
 @Injectable({

--- a/src/app/cores/services/dataset-upload.service.ts
+++ b/src/app/cores/services/dataset-upload.service.ts
@@ -5,8 +5,6 @@ import { environment } from "../../../environments/environment";
 
 export interface DatasetUploadRequest {
   formData: Record<string, unknown>;
-  datasetName?: string;
-  datasetDescription?: string;
 }
 
 export interface DatasetUploadResponse {

--- a/src/app/cores/services/workflow-submission.service.ts
+++ b/src/app/cores/services/workflow-submission.service.ts
@@ -1,5 +1,6 @@
 import { inject, Injectable, signal } from "@angular/core";
 import { Router } from "@angular/router";
+import { getErrorMessage } from "../utils/error.utils";
 import { WorkflowApiService } from "./workflow-api.service";
 
 @Injectable({
@@ -91,17 +92,14 @@ export class WorkflowSubmissionService {
         },
         error: (error) => {
           console.error("Error launching workflow:", error);
-          // Hide loading state
           this.isSubmitting.set(false);
 
-          // Call custom error handler if provided
+          const message = getErrorMessage(error);
+
           if (onError) {
-            onError(error);
+            onError(new Error(message));
           } else {
-            // Default error handling
-            alert(
-              `Failed to launch workflow: ${error.message || "Unknown error"}`
-            );
+            alert(`Failed to launch workflow: ${message}`);
           }
         },
       });

--- a/src/app/cores/utils/error.utils.spec.ts
+++ b/src/app/cores/utils/error.utils.spec.ts
@@ -1,0 +1,79 @@
+import { getErrorMessage } from "./error.utils";
+
+describe("getErrorMessage", () => {
+  it("returns fallback for null", () => {
+    expect(getErrorMessage(null)).toBe("Unknown error");
+  });
+
+  it("returns fallback for undefined", () => {
+    expect(getErrorMessage(undefined)).toBe("Unknown error");
+  });
+
+  it("accepts a custom fallback", () => {
+    expect(getErrorMessage(null, "oops")).toBe("oops");
+  });
+
+  it("returns network message for status 0", () => {
+    expect(getErrorMessage({ status: 0 })).toBe(
+      "Cannot reach the server — check your connection or try again."
+    );
+  });
+
+  it("does not treat non-zero status as network error", () => {
+    const err = { status: 422, error: { detail: "bad input" } };
+    expect(getErrorMessage(err)).toBe("bad input");
+  });
+
+  it("returns string detail from error body", () => {
+    const err = { error: { detail: "Not found" } };
+    expect(getErrorMessage(err)).toBe("Not found");
+  });
+
+  it("ignores empty string detail and falls through", () => {
+    const err = { error: { detail: "", message: "fallback msg" } };
+    expect(getErrorMessage(err)).toBe("fallback msg");
+  });
+
+  it("joins Pydantic 422 array detail using msg fields", () => {
+    const err = {
+      error: {
+        detail: [
+          { msg: "field required", loc: ["body", "name"] },
+          { msg: "Extra inputs are not permitted", loc: ["body", "foo"] },
+        ],
+      },
+    };
+    expect(getErrorMessage(err)).toBe(
+      "field required; Extra inputs are not permitted"
+    );
+  });
+
+  it("falls back to JSON.stringify for array items without msg", () => {
+    const err = { error: { detail: [{ type: "missing" }] } };
+    expect(getErrorMessage(err)).toBe('{"type":"missing"}');
+  });
+
+  it("ignores empty detail array and falls through", () => {
+    const err = { error: { detail: [], message: "body message" } };
+    expect(getErrorMessage(err)).toBe("body message");
+  });
+
+  it("returns body.message when detail is absent", () => {
+    const err = { error: { message: "Service unavailable" } };
+    expect(getErrorMessage(err)).toBe("Service unavailable");
+  });
+
+  it("returns top-level message when error body is absent", () => {
+    const err = { message: "Http failure response: 503" };
+    expect(getErrorMessage(err)).toBe("Http failure response: 503");
+  });
+
+  it("returns fallback when no message fields are present", () => {
+    expect(getErrorMessage({ status: 500 })).toBe("Unknown error");
+  });
+
+  it("returns fallback when status is not a number", () => {
+    const err = { status: "0", message: "some msg" };
+    expect(getErrorMessage(err)).toBe("some msg");
+  });
+});

--- a/src/app/cores/utils/error.utils.ts
+++ b/src/app/cores/utils/error.utils.ts
@@ -1,0 +1,19 @@
+/**
+ * Extract a human-readable message from an Angular HttpErrorResponse or plain Error.
+ * FastAPI surfaces the useful text in `error.error.detail`; this helper checks that
+ * first before falling back to the generic Angular message.
+ */
+export function getErrorMessage(
+  error: unknown,
+  fallback = "Unknown error"
+): string {
+  if (error == null) return fallback;
+  const e = error as Record<string, unknown>;
+  const body = e["error"] as Record<string, unknown> | undefined;
+  return (
+    (body?.["detail"] as string | undefined) ||
+    (body?.["message"] as string | undefined) ||
+    (e["message"] as string | undefined) ||
+    fallback
+  );
+}

--- a/src/app/cores/utils/error.utils.ts
+++ b/src/app/cores/utils/error.utils.ts
@@ -1,7 +1,7 @@
 /**
  * Extract a human-readable message from an Angular HttpErrorResponse or plain Error.
- * FastAPI surfaces the useful text in `error.error.detail`; this helper checks that
- * first before falling back to the generic Angular message.
+ * FastAPI surfaces the useful text in `error.error.detail`; for 422 responses that
+ * field is an array of Pydantic validation objects — this helper handles both cases.
  */
 export function getErrorMessage(
   error: unknown,
@@ -9,9 +9,23 @@ export function getErrorMessage(
 ): string {
   if (error == null) return fallback;
   const e = error as Record<string, unknown>;
+  if (typeof e["status"] === "number" && e["status"] === 0) {
+    return "Cannot reach the server — check your connection or try again.";
+  }
   const body = e["error"] as Record<string, unknown> | undefined;
+  const detail = body?.["detail"];
+  if (typeof detail === "string" && detail) return detail;
+  if (Array.isArray(detail) && detail.length > 0) {
+    return detail
+      .map((d: unknown) => {
+        const item = d as Record<string, unknown>;
+        return typeof item?.["msg"] === "string"
+          ? item["msg"]
+          : JSON.stringify(d);
+      })
+      .join("; ");
+  }
   return (
-    (body?.["detail"] as string | undefined) ||
     (body?.["message"] as string | undefined) ||
     (e["message"] as string | undefined) ||
     fallback

--- a/src/app/cores/utils/fasta.utils.spec.ts
+++ b/src/app/cores/utils/fasta.utils.spec.ts
@@ -7,6 +7,7 @@ import {
   validateMultiFastaProtein,
   validateProteinSequence,
   validateRnaSequence,
+  validateUniqueHeadersAcrossInputs,
 } from "./fasta.utils";
 
 describe("fasta.utils", () => {
@@ -283,6 +284,45 @@ describe("fasta.utils", () => {
         valid: true,
         sequenceCount: 1,
       });
+    });
+  });
+
+  describe("validateUniqueHeadersAcrossInputs", () => {
+    it("returns valid when all headers are unique across both inputs", () => {
+      expect(
+        validateUniqueHeadersAcrossInputs(
+          ">query1\nMKTAYIAK",
+          ">target1\nACDEFGHIK"
+        )
+      ).toEqual({ valid: true });
+    });
+
+    it("returns invalid when a header appears in both inputs", () => {
+      const result = validateUniqueHeadersAcrossInputs(
+        ">seq1\nMKTAYIAK",
+        ">seq1\nACDEFGHIK"
+      );
+      expect(result.valid).toBe(false);
+      expect(result.errorMessage).toContain('"seq1"');
+    });
+
+    it("reports multiple duplicate headers", () => {
+      const result = validateUniqueHeadersAcrossInputs(
+        ">seq1\nMKTAYIAK\n>seq2\nACDEFGHIK",
+        ">seq1\nMKTAYIAK\n>seq2\nACDEFGHIK"
+      );
+      expect(result.valid).toBe(false);
+      expect(result.errorMessage).toContain('"seq1"');
+      expect(result.errorMessage).toContain('"seq2"');
+    });
+
+    it("returns valid when inputs have no overlapping headers", () => {
+      expect(
+        validateUniqueHeadersAcrossInputs(
+          ">a\nMKT\n>b\nACDE",
+          ">c\nMKT\n>d\nACDE"
+        )
+      ).toEqual({ valid: true });
     });
   });
 

--- a/src/app/cores/utils/fasta.utils.ts
+++ b/src/app/cores/utils/fasta.utils.ts
@@ -196,6 +196,25 @@ export function parseMultiFasta(
     });
 }
 
+/**
+ * Checks that no sequence ID appears in both FASTA inputs.
+ * Assumes both inputs have already passed `validateMultiFastaProtein`.
+ */
+export function validateUniqueHeadersAcrossInputs(
+  input1: string,
+  input2: string
+): SequenceValidationResult {
+  const headers1 = new Set(parseMultiFasta(input1).map((e) => e.header));
+  const duplicates = parseMultiFasta(input2)
+    .map((e) => e.header)
+    .filter((h) => headers1.has(h));
+  if (duplicates.length === 0) return { valid: true };
+  return {
+    valid: false,
+    errorMessage: `Sequence ID${duplicates.length > 1 ? "s" : ""} must be unique across query and target. Duplicate${duplicates.length > 1 ? "s" : ""}: ${duplicates.map((h) => `"${h}"`).join(", ")}.`,
+  };
+}
+
 export const validateDnaSequence = createSequenceValidator(
   /^[ATGC]+$/,
   "DNA sequence is required.",

--- a/src/app/cores/utils/fasta.utils.ts
+++ b/src/app/cores/utils/fasta.utils.ts
@@ -211,7 +211,11 @@ export function validateUniqueHeadersAcrossInputs(
   if (duplicates.length === 0) return { valid: true };
   return {
     valid: false,
-    errorMessage: `Sequence ID${duplicates.length > 1 ? "s" : ""} must be unique across query and target. Duplicate${duplicates.length > 1 ? "s" : ""}: ${duplicates.map((h) => `"${h}"`).join(", ")}.`,
+    errorMessage: `Sequence ID${
+      duplicates.length > 1 ? "s" : ""
+    } must be unique across query and target. Duplicate${
+      duplicates.length > 1 ? "s" : ""
+    }: ${duplicates.map((h) => `"${h}"`).join(", ")}.`,
   };
 }
 

--- a/src/app/pages/workflow/de-novo-design/de-novo-design.ts
+++ b/src/app/pages/workflow/de-novo-design/de-novo-design.ts
@@ -40,6 +40,7 @@ import { PdbUploadService } from "../../../cores/services/pdb-upload.service";
 import { SchemaLoaderService } from "../../../cores/services/schema-loader.service";
 import { WorkflowSubmissionService } from "../../../cores/services/workflow-submission.service";
 import { WORKFLOW_INPUT_DIRS } from "../../../cores/config/workflow-paths";
+import { getErrorMessage } from "../../../cores/utils/error.utils";
 
 interface TabItem {
   id: "overview" | "output" | "papers";
@@ -637,8 +638,7 @@ export class DeNovoDesignComponent implements OnInit, OnDestroy {
             error: (error) => {
               this.isPdbUploading.set(false);
               this.workflowSubmission.isSubmitting.set(false);
-              const msg =
-                error?.error?.message ?? error?.message ?? "Unknown error";
+              const msg = getErrorMessage(error);
               this.showError(
                 `Failed to upload PDB file: ${msg}. Please try again.`
               );
@@ -705,9 +705,7 @@ export class DeNovoDesignComponent implements OnInit, OnDestroy {
         error: (error) => {
           console.error("Dataset upload failed", error);
           this.workflowSubmission.isSubmitting.set(false);
-          this.showError(
-            `Failed to upload dataset: ${error.message || "Unknown error"}`
-          );
+          this.showError(`Failed to upload dataset: ${getErrorMessage(error)}`);
         },
       });
   }

--- a/src/app/pages/workflow/interaction-screening/interaction-screening.html
+++ b/src/app/pages/workflow/interaction-screening/interaction-screening.html
@@ -211,7 +211,7 @@
                 autocapitalize="off"
                 [formControl]="form.controls.queryFasta"
                 [class]="
-                  hasQueryError()
+                  hasQueryError() || hasDuplicateSequencesError()
                     ? 'border-red-400 focus:ring-red-400 focus:border-red-400'
                     : 'border-gray-300 focus:ring-blue-500 focus:border-blue-500'
                 "
@@ -250,7 +250,7 @@
                 autocapitalize="off"
                 [formControl]="form.controls.targetFasta"
                 [class]="
-                  hasTargetError()
+                  hasTargetError() || hasDuplicateSequencesError()
                     ? 'border-red-400 focus:ring-red-400 focus:border-red-400'
                     : 'border-gray-300 focus:ring-blue-500 focus:border-blue-500'
                 "
@@ -264,6 +264,10 @@
               } @if (hasProductError()) {
               <p class="mt-2 text-xs text-red-600" role="alert">
                 {{ getProductError() }}
+              </p>
+              } @if (hasDuplicateSequencesError()) {
+              <p class="mt-2 text-xs text-red-600" role="alert">
+                {{ getDuplicateSequencesError() }}
               </p>
               }
             </div>

--- a/src/app/pages/workflow/interaction-screening/interaction-screening.spec.ts
+++ b/src/app/pages/workflow/interaction-screening/interaction-screening.spec.ts
@@ -6,6 +6,7 @@ import {
   FastaUploadResponse,
   FastaUploadService,
 } from "../../../cores/services/fasta-upload.service";
+import { DatasetUploadService } from "../../../cores/services/dataset-upload.service";
 import { WorkflowSubmissionService } from "../../../cores/services/workflow-submission.service";
 import { InteractionScreeningComponent } from "./interaction-screening";
 
@@ -23,12 +24,19 @@ const MOCK_FASTA_RESPONSE: FastaUploadResponse = {
   presignedUrl: "https://signed.example/querySeq1.fasta",
 };
 
+const MOCK_DATASET_RESPONSE = {
+  success: true,
+  message: "ok",
+  datasetId: "dataset-123",
+};
+
 // ──────────────────────────────────────────────────────────────────────────
 
 describe("InteractionScreeningComponent", () => {
   let component: InteractionScreeningComponent;
   let fixture: ComponentFixture<InteractionScreeningComponent>;
   let fastaUploadService: jasmine.SpyObj<FastaUploadService>;
+  let datasetUploadService: jasmine.SpyObj<DatasetUploadService>;
   let workflowSubmissionService: {
     isSubmitting: ReturnType<typeof signal<boolean>>;
     showSuccessDialog: ReturnType<typeof signal<boolean>>;
@@ -52,11 +60,23 @@ describe("InteractionScreeningComponent", () => {
     );
     fastaUploadService.uploadFastaFile.and.returnValue(of(MOCK_FASTA_RESPONSE));
 
+    datasetUploadService = jasmine.createSpyObj<DatasetUploadService>(
+      "DatasetUploadService",
+      ["uploadInteractionScreeningDataset"]
+    );
+    datasetUploadService.uploadInteractionScreeningDataset.and.returnValue(
+      of(MOCK_DATASET_RESPONSE)
+    );
+
     workflowSubmissionService = {
       isSubmitting: signal(false),
       showSuccessDialog: signal(false),
       successDialogData: signal(null),
-      submitWorkflowWithDataset: jasmine.createSpy("submitWorkflowWithDataset"),
+      submitWorkflowWithDataset: jasmine
+        .createSpy("submitWorkflowWithDataset")
+        .and.callFake(() => {
+          workflowSubmissionService.isSubmitting.set(false);
+        }),
       goToJobs: jasmine.createSpy("goToJobs"),
     };
 
@@ -72,6 +92,7 @@ describe("InteractionScreeningComponent", () => {
       providers: [
         { provide: AuthService, useValue: authService },
         { provide: FastaUploadService, useValue: fastaUploadService },
+        { provide: DatasetUploadService, useValue: datasetUploadService },
         {
           provide: WorkflowSubmissionService,
           useValue: workflowSubmissionService,
@@ -119,14 +140,14 @@ describe("InteractionScreeningComponent", () => {
     expect(fastaUploadService.uploadFastaFile).not.toHaveBeenCalled();
   });
 
-  it("should call uploadFastaFile once per sequence (2 calls for query + target) when form is valid", () => {
+  it("should call uploadFastaFile once with combined sequences when form is valid", () => {
     fillValidForm();
     fixture.detectChanges();
 
     component.submitWorkflow();
 
-    // one query sequence + one target sequence = 2 uploads
-    expect(fastaUploadService.uploadFastaFile).toHaveBeenCalledTimes(2);
+    // all sequences combined into a single FASTA file upload
+    expect(fastaUploadService.uploadFastaFile).toHaveBeenCalledTimes(1);
   });
 
   it("should set isSubmitting to false on successful upload", () => {
@@ -452,6 +473,62 @@ describe("InteractionScreeningComponent", () => {
     fixture.detectChanges();
     fastaUploadService.uploadFastaFile.and.returnValue(throwError(() => ({})));
     component.submitWorkflow();
+    expect(component.alertMessage()).toContain("Unknown error");
+  });
+
+  // ── 23. submitWorkflow — missing datasetId ────────────────────────────────
+
+  it("should show error and set isSubmitting false when dataset upload returns no datasetId", () => {
+    fillValidForm();
+    fixture.detectChanges();
+    datasetUploadService.uploadInteractionScreeningDataset.and.returnValue(
+      of({ success: true, message: "ok" })
+    );
+
+    component.submitWorkflow();
+
+    expect(workflowSubmissionService.isSubmitting()).toBe(false);
+    expect(component.showAlert()).toBe(true);
+    expect(component.alertMessage()).toContain("no dataset ID");
+  });
+
+  // ── 24. submitWorkflow — workflow launch error callback ───────────────────
+
+  it("should show error when submitWorkflowWithDataset calls the error callback", () => {
+    fillValidForm();
+    fixture.detectChanges();
+    workflowSubmissionService.submitWorkflowWithDataset.and.callFake(
+      (
+        _options: unknown,
+        _datasetId: string,
+        errorCallback: (err: Error) => void
+      ) => {
+        errorCallback(new Error("launch failed"));
+      }
+    );
+
+    component.submitWorkflow();
+
+    expect(component.showAlert()).toBe(true);
+    expect(component.alertMessage()).toContain("launch failed");
+    expect(workflowSubmissionService.isSubmitting()).toBe(false);
+  });
+
+  it("should show 'Unknown error' when the workflow launch error has no message", () => {
+    fillValidForm();
+    fixture.detectChanges();
+    workflowSubmissionService.submitWorkflowWithDataset.and.callFake(
+      (
+        _options: unknown,
+        _datasetId: string,
+        errorCallback: (err: Error) => void
+      ) => {
+        errorCallback({} as Error);
+      }
+    );
+
+    component.submitWorkflow();
+
     expect(component.alertMessage()).toContain("Unknown error");
   });
 });

--- a/src/app/pages/workflow/interaction-screening/interaction-screening.ts
+++ b/src/app/pages/workflow/interaction-screening/interaction-screening.ts
@@ -408,8 +408,6 @@ export class InteractionScreeningComponent {
           this.datasetUploadService.uploadInteractionScreeningDataset({
             sequences: sequences.map((s) => ({ id: s.id, group: s.group })),
             runId: jobName,
-            datasetName: `${jobName}-samplesheet-${Date.now()}`,
-            datasetDescription: "Interaction screening samplesheet",
           })
         )
       )

--- a/src/app/pages/workflow/interaction-screening/interaction-screening.ts
+++ b/src/app/pages/workflow/interaction-screening/interaction-screening.ts
@@ -34,10 +34,7 @@ import {
 } from "../../../cores/utils/fasta.utils";
 import { environment } from "../../../../environments/environment";
 import { AuthService } from "../../../cores/auth.service";
-import {
-  FastaUploadResponse,
-  FastaUploadService,
-} from "../../../cores/services/fasta-upload.service";
+import { FastaUploadService } from "../../../cores/services/fasta-upload.service";
 import { DatasetUploadService } from "../../../cores/services/dataset-upload.service";
 import { WorkflowSubmissionService } from "../../../cores/services/workflow-submission.service";
 import { WORKFLOW_INPUT_DIRS } from "../../../cores/config/workflow-paths";
@@ -364,7 +361,11 @@ export class InteractionScreeningComponent {
 
   // ─── Submission ───────────────────────────────────────────────────────────
 
-  private buildWispsPayload(): { id: string; sequence: string; group: "query" | "target" }[] {
+  private buildWispsPayload(): {
+    id: string;
+    sequence: string;
+    group: "query" | "target";
+  }[] {
     const queryEntries = parseMultiFasta(this.form.value.queryFasta ?? "");
     const targetEntries = parseMultiFasta(this.form.value.targetFasta ?? "");
     return [

--- a/src/app/pages/workflow/interaction-screening/interaction-screening.ts
+++ b/src/app/pages/workflow/interaction-screening/interaction-screening.ts
@@ -50,7 +50,6 @@ function multiFastaValidator(
 }
 
 const MAX_SEQUENCE_PRODUCT = 1000;
-const BASE_PATH = "/g/data/yz52/sbp-service/input/";
 
 function maxProductValidator(max: number): ValidatorFn {
   return (group: AbstractControl): ValidationErrors | null => {
@@ -382,20 +381,6 @@ export class InteractionScreeningComponent {
     ];
   }
 
-  private buildSamplesheetFormData(
-    sequences: { id: string; group: "query" | "target" }[],
-    runId: string
-  ): Record<string, unknown> {
-    return {
-      id: sequences.map((s) => s.id),
-      sequence: sequences.map(
-        (s) => `${BASE_PATH}/${runId}/${s.id}.fasta`
-      ),
-      group: sequences.map((s) => (s.group === "target" ? "g1" : "g2")),
-      type: sequences.map(() => "protein"),
-    };
-  }
-
   submitWorkflow() {
     if (!this.isFormValid()) {
       console.error("Cannot submit: Form validation failed");
@@ -419,17 +404,14 @@ export class InteractionScreeningComponent {
 
     upload$
       .pipe(
-        switchMap(() => {
-          const formData = this.buildSamplesheetFormData(
-            sequences,
-            jobName
-          );
-          return this.datasetUploadService.uploadDataset({
-            formData,
+        switchMap(() =>
+          this.datasetUploadService.uploadInteractionScreeningDataset({
+            sequences: sequences.map((s) => ({ id: s.id, group: s.group })),
+            runId: jobName,
             datasetName: `${jobName}-samplesheet-${Date.now()}`,
             datasetDescription: "Interaction screening samplesheet",
-          });
-        })
+          })
+        )
       )
       .subscribe({
         next: (datasetResponse) => {

--- a/src/app/pages/workflow/interaction-screening/interaction-screening.ts
+++ b/src/app/pages/workflow/interaction-screening/interaction-screening.ts
@@ -12,7 +12,6 @@ import {
   JOB_NAME_VALIDATORS,
   jobNameErrorMessage,
 } from "../../../cores/utils/job-name.utils";
-import { forkJoin, of } from "rxjs";
 import { map, startWith, switchMap } from "rxjs/operators";
 import { AlertComponent } from "../../../components/alert/alert.component";
 import { ButtonComponent } from "../../../components/button/button.component";
@@ -51,6 +50,7 @@ function multiFastaValidator(
 }
 
 const MAX_SEQUENCE_PRODUCT = 1000;
+const BASE_PATH = "/g/data/yz52/sbp-service/input/";
 
 function maxProductValidator(max: number): ValidatorFn {
   return (group: AbstractControl): ValidationErrors | null => {
@@ -384,11 +384,13 @@ export class InteractionScreeningComponent {
 
   private buildSamplesheetFormData(
     sequences: { id: string; group: "query" | "target" }[],
-    uploadResponses: FastaUploadResponse[]
+    runId: string
   ): Record<string, unknown> {
     return {
       id: sequences.map((s) => s.id),
-      sequence: uploadResponses.map((r) => r.s3Uri),
+      sequence: sequences.map(
+        (s) => `${BASE_PATH}/${runId}/${s.id}.fasta`
+      ),
       group: sequences.map((s) => (s.group === "target" ? "g1" : "g2")),
       type: sequences.map(() => "protein"),
     };
@@ -405,27 +407,22 @@ export class InteractionScreeningComponent {
 
     this.workflowSubmission.isSubmitting.set(true);
 
-    const uploadObservables = sequences.map((seq) => {
-      const fastaContent = `>${seq.id}\n${seq.sequence}`;
-      const blob = new Blob([fastaContent], { type: "text/plain" });
-      const file = new File([blob], `${seq.id}.fasta`, { type: "text/plain" });
-      return this.fastaUploadService.uploadFastaFile({
-        file,
-        folder: WORKFLOW_INPUT_DIRS.INTERACTION_SCREENING,
-      });
+    const combinedFasta = sequences
+      .map((seq) => `>${seq.id}\n${seq.sequence}`)
+      .join("\n");
+    const blob = new Blob([combinedFasta], { type: "text/plain" });
+    const file = new File([blob], `sequences.fasta`, { type: "text/plain" });
+    const upload$ = this.fastaUploadService.uploadFastaFile({
+      file,
+      folder: WORKFLOW_INPUT_DIRS.INTERACTION_SCREENING,
     });
 
-    const uploads$ =
-      uploadObservables.length > 0
-        ? forkJoin(uploadObservables)
-        : of([] as FastaUploadResponse[]);
-
-    uploads$
+    upload$
       .pipe(
-        switchMap((uploadResponses) => {
+        switchMap(() => {
           const formData = this.buildSamplesheetFormData(
             sequences,
-            uploadResponses
+            jobName
           );
           return this.datasetUploadService.uploadDataset({
             formData,

--- a/src/app/pages/workflow/interaction-screening/interaction-screening.ts
+++ b/src/app/pages/workflow/interaction-screening/interaction-screening.ts
@@ -38,6 +38,7 @@ import { FastaUploadService } from "../../../cores/services/fasta-upload.service
 import { DatasetUploadService } from "../../../cores/services/dataset-upload.service";
 import { WorkflowSubmissionService } from "../../../cores/services/workflow-submission.service";
 import { WORKFLOW_INPUT_DIRS } from "../../../cores/config/workflow-paths";
+import { getErrorMessage } from "../../../cores/utils/error.utils";
 
 function multiFastaValidator(
   control: AbstractControl
@@ -435,7 +436,7 @@ export class InteractionScreeningComponent {
         },
         error: (error) => {
           this.workflowSubmission.isSubmitting.set(false);
-          this.showError(error.message || "Unknown error");
+          this.showError(getErrorMessage(error));
         },
       });
   }

--- a/src/app/pages/workflow/interaction-screening/interaction-screening.ts
+++ b/src/app/pages/workflow/interaction-screening/interaction-screening.ts
@@ -13,7 +13,7 @@ import {
   jobNameErrorMessage,
 } from "../../../cores/utils/job-name.utils";
 import { forkJoin, of } from "rxjs";
-import { map, startWith } from "rxjs/operators";
+import { map, startWith, switchMap } from "rxjs/operators";
 import { AlertComponent } from "../../../components/alert/alert.component";
 import { ButtonComponent } from "../../../components/button/button.component";
 import { DialogComponent } from "../../../components/dialog/dialog.component";
@@ -38,6 +38,7 @@ import {
   FastaUploadResponse,
   FastaUploadService,
 } from "../../../cores/services/fasta-upload.service";
+import { DatasetUploadService } from "../../../cores/services/dataset-upload.service";
 import { WorkflowSubmissionService } from "../../../cores/services/workflow-submission.service";
 import { WORKFLOW_INPUT_DIRS } from "../../../cores/config/workflow-paths";
 
@@ -102,6 +103,8 @@ export class InteractionScreeningComponent {
   public workflowSubmission = inject(WorkflowSubmissionService);
   // FASTA upload service
   private fastaUploadService = inject(FastaUploadService);
+  // Dataset upload service
+  private datasetUploadService = inject(DatasetUploadService);
   // Form
   private fb = inject(NonNullableFormBuilder);
   readonly form = this.fb.group(
@@ -333,26 +336,33 @@ export class InteractionScreeningComponent {
 
   // ─── Submission ───────────────────────────────────────────────────────────
 
-  /**
-   * Build the wisps-compatible payload array.
-   * Each element matches the wisps schema_input row: { id, sequence, group }.
-   * Whitespace normalisation matches the validator (replace(/\s+/g, "")).
-   */
-  private buildWispsPayload(): Record<string, unknown>[] {
+  private buildWispsPayload(): { id: string; sequence: string; group: "query" | "target" }[] {
     const queryEntries = parseMultiFasta(this.form.value.queryFasta ?? "");
     const targetEntries = parseMultiFasta(this.form.value.targetFasta ?? "");
     return [
       ...queryEntries.map((e) => ({
         id: e.header,
         sequence: e.sequence,
-        group: "query",
+        group: "query" as const,
       })),
       ...targetEntries.map((e) => ({
         id: e.header,
         sequence: e.sequence,
-        group: "target",
+        group: "target" as const,
       })),
     ];
+  }
+
+  private buildSamplesheetFormData(
+    sequences: { id: string; group: "query" | "target" }[],
+    uploadResponses: FastaUploadResponse[]
+  ): Record<string, unknown> {
+    return {
+      id: sequences.map((s) => s.id),
+      sequence: uploadResponses.map((r) => r.s3Uri),
+      group: sequences.map((s) => (s.group === "target" ? "g1" : "g2")),
+      type: sequences.map(() => "protein"),
+    };
   }
 
   submitWorkflow() {
@@ -361,16 +371,15 @@ export class InteractionScreeningComponent {
       return;
     }
 
+    const jobName = this.form.value.jobName ?? "";
     const sequences = this.buildWispsPayload();
 
     this.workflowSubmission.isSubmitting.set(true);
 
     const uploadObservables = sequences.map((seq) => {
-      const id = seq["id"] as string;
-      const sequence = seq["sequence"] as string;
-      const fastaContent = `>${id}\n${sequence}`;
+      const fastaContent = `>${seq.id}\n${seq.sequence}`;
       const blob = new Blob([fastaContent], { type: "text/plain" });
-      const file = new File([blob], `${id}.fasta`, { type: "text/plain" });
+      const file = new File([blob], `${seq.id}.fasta`, { type: "text/plain" });
       return this.fastaUploadService.uploadFastaFile({
         file,
         folder: WORKFLOW_INPUT_DIRS.INTERACTION_SCREENING,
@@ -382,19 +391,46 @@ export class InteractionScreeningComponent {
         ? forkJoin(uploadObservables)
         : of([] as FastaUploadResponse[]);
 
-    uploads$.subscribe({
-      next: (uploadResponses) => {
-        const fastaS3Uris = uploadResponses.map((r) => r.s3Uri);
-        console.log("FASTA uploads complete:", fastaS3Uris);
-        this.workflowSubmission.isSubmitting.set(false);
-      },
-      error: (error) => {
-        this.workflowSubmission.isSubmitting.set(false);
-        this.showError(
-          `Failed to upload FASTA files: ${error.message || "Unknown error"}`
-        );
-      },
-    });
+    uploads$
+      .pipe(
+        switchMap((uploadResponses) => {
+          const formData = this.buildSamplesheetFormData(
+            sequences,
+            uploadResponses
+          );
+          return this.datasetUploadService.uploadDataset({
+            formData,
+            datasetName: `${jobName}-samplesheet-${Date.now()}`,
+            datasetDescription: "Interaction screening samplesheet",
+          });
+        })
+      )
+      .subscribe({
+        next: (datasetResponse) => {
+          const datasetId = datasetResponse.datasetId;
+          if (!datasetId) {
+            this.workflowSubmission.isSubmitting.set(false);
+            this.showError(
+              "Dataset upload succeeded but no dataset ID was returned."
+            );
+            return;
+          }
+          this.workflowSubmission.submitWorkflowWithDataset(
+            { tool: this.selectedToolLabel(), runName: jobName },
+            datasetId,
+            (error) => {
+              this.workflowSubmission.isSubmitting.set(false);
+              this.showError(
+                `Workflow launch failed: ${error.message || "Unknown error"}`
+              );
+            }
+          );
+        },
+        error: (error) => {
+          this.workflowSubmission.isSubmitting.set(false);
+          this.showError(error.message || "Unknown error");
+        },
+      });
   }
 
   submitNewJob() {

--- a/src/app/pages/workflow/interaction-screening/interaction-screening.ts
+++ b/src/app/pages/workflow/interaction-screening/interaction-screening.ts
@@ -29,6 +29,7 @@ import {
   ToolSelectionComponent,
 } from "../../../components/workflow/tool-selection/tool-selection.component";
 import {
+  validateUniqueHeadersAcrossInputs,
   parseMultiFasta,
   validateMultiFastaProtein,
 } from "../../../cores/utils/fasta.utils";
@@ -61,6 +62,21 @@ function maxProductValidator(max: number): ValidatorFn {
     const product = queryResult.sequenceCount * targetResult.sequenceCount;
     return product >= max ? { maxProduct: { actual: product, max } } : null;
   };
+}
+
+function uniqueSequencesValidator(
+  group: AbstractControl
+): ValidationErrors | null {
+  const queryVal = group.get("queryFasta")?.value ?? "";
+  const targetVal = group.get("targetFasta")?.value ?? "";
+  if (
+    !validateMultiFastaProtein(queryVal).valid ||
+    !validateMultiFastaProtein(targetVal).valid
+  ) {
+    return null;
+  }
+  const result = validateUniqueHeadersAcrossInputs(queryVal, targetVal);
+  return result.valid ? null : { duplicateSequences: result.errorMessage };
 }
 
 interface TabItem {
@@ -113,7 +129,12 @@ export class InteractionScreeningComponent {
       queryFasta: ["", multiFastaValidator],
       targetFasta: ["", multiFastaValidator],
     },
-    { validators: maxProductValidator(MAX_SEQUENCE_PRODUCT) }
+    {
+      validators: [
+        maxProductValidator(MAX_SEQUENCE_PRODUCT),
+        uniqueSequencesValidator,
+      ],
+    }
   );
   private formStatus = toSignal(
     this.form.statusChanges.pipe(startWith(this.form.status))
@@ -328,6 +349,14 @@ export class InteractionScreeningComponent {
     return `Too many sequence combinations: ${
       err.actual
     } pairs (query × target). The maximum is ${err.max - 1}.`;
+  }
+
+  hasDuplicateSequencesError(): boolean {
+    return !!this.form.errors?.["duplicateSequences"];
+  }
+
+  getDuplicateSequencesError(): string {
+    return this.form.errors?.["duplicateSequences"] ?? "";
   }
 
   private touchAll(): void {

--- a/src/app/pages/workflow/single-prediction/single-prediction.spec.ts
+++ b/src/app/pages/workflow/single-prediction/single-prediction.spec.ts
@@ -519,10 +519,6 @@ describe("SinglePredictionComponent", () => {
           id: "single_prediction",
           fasta: MOCK_FASTA_RESPONSE.s3Uri,
         },
-        datasetName: jasmine.stringMatching(
-          /^single_prediction-samplesheet-\d+$/
-        ),
-        datasetDescription: "Single prediction samplesheet",
       })
     );
     expect(

--- a/src/app/pages/workflow/single-prediction/single-prediction.ts
+++ b/src/app/pages/workflow/single-prediction/single-prediction.ts
@@ -820,8 +820,6 @@ export class SinglePredictionComponent {
           return this.datasetUploadService
             .uploadDataset({
               formData: { id: this.samplesheetId, fasta: response.s3Uri },
-              datasetName: `${this.samplesheetId}-samplesheet-${Date.now()}`,
-              datasetDescription: "Single prediction samplesheet",
             })
             .pipe(
               map((datasetResponse) => ({

--- a/src/app/pages/workflow/single-prediction/single-prediction.ts
+++ b/src/app/pages/workflow/single-prediction/single-prediction.ts
@@ -35,6 +35,7 @@ import { DatasetUploadService } from "../../../cores/services/dataset-upload.ser
 import { FastaUploadService } from "../../../cores/services/fasta-upload.service";
 import { WorkflowSubmissionService } from "../../../cores/services/workflow-submission.service";
 import { WORKFLOW_INPUT_DIRS } from "../../../cores/config/workflow-paths";
+import { getErrorMessage } from "../../../cores/utils/error.utils";
 import {
   CCD_COMPOUNDS,
   isValidSmiles,
@@ -845,9 +846,9 @@ export class SinglePredictionComponent {
           this.preparedSamplesheetDatasetId.set(datasetId);
           onPrepared(fastaUrl, datasetId);
         },
-        error: (error: Error) => {
+        error: (error: unknown) => {
           this.workflowSubmission.isSubmitting.set(false);
-          this.showError(error.message || "Unknown error");
+          this.showError(getErrorMessage(error));
         },
       });
   }


### PR DESCRIPTION
<!--
Thank you for contributing! Please fill out the sections below to help maintainers review your change faster.
Delete any sections that don't apply.
-->

# Pull Request

## Summary

[SBP-364](https://biocloud.atlassian.net/browse/SBP-364) — Extends the Interaction Screening workflow to upload query and target protein sequences as a single combined FASTA file to S3, then register a named dataset via the backend API before launching the workflow. Also adds cross-input duplicate header validation so users are warned when the same sequence ID appears in both query and target inputs.

## Changes

- **`dataset-upload.service.ts`**: Added `InteractionScreeningDatasetUploadRequest` interface and `uploadInteractionScreeningDataset()` method posting to `/api/workflows/datasets/interaction-screening/upload`
- **`fasta.utils.ts`**: Added `validateUniqueHeadersAcrossInputs()` utility that detects duplicate FASTA headers across two separate inputs
- **`interaction-screening.ts`**: Replaced per-sequence `forkJoin` upload with a single combined FASTA upload followed by dataset registration via `DatasetUploadService`; added `uniqueSequencesValidator` form group validator; wires dataset ID into `submitWorkflowWithDataset`
- **`interaction-screening.html`**: Highlights query/target textareas and shows an inline error when duplicate sequence IDs are detected across inputs
- **`interaction-screening.spec.ts`**: Fixed 41 failing CI tests by adding missing `DatasetUploadService` mock; corrected upload-call-count expectation (1 combined upload, not 2 per-sequence); added branch-coverage tests for missing-datasetId and workflow-launch-error-callback paths
- **`dataset-upload.service.spec.ts`**: Added test for `uploadInteractionScreeningDataset` to meet the 80% per-file function coverage threshold
- **`fasta.utils.spec.ts`**: Added tests for `validateUniqueHeadersAcrossInputs` to meet the 80% per-file function coverage threshold

## How to Test

1. Start the portal locally: `npm start`
2. Navigate to the **Interaction Screening** workflow page
3. Enter valid multi-FASTA sequences in both **Query** and **Target** fields (e.g. `>seq1\nARNDC`)
4. Verify the form accepts unique headers across inputs and rejects duplicates with an inline error on both textareas
5. Fill in a job name and advance through the steps to **Review & Submit**
6. Submit — confirm a single combined `.fasta` file is uploaded to S3 and a dataset is registered via the backend before the workflow launches
7. Run `npm run test:ci` locally — 716 tests should pass with no per-file coverage violations

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added or updated documentation where necessary
- [x] I have run linting and unit tests locally
- [x] The code follows the project's style guidelines


[SBP-364]: https://biocloud.atlassian.net/browse/SBP-364?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ