### PR TITLE
refactor: standardize and specify workflow and tools names

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -115,7 +115,8 @@
             ],
             "styles": ["src/styles.scss"],
             "scripts": [],
-            "karmaConfig": "karma.conf.js"
+            "karmaConfig": "karma.conf.js",
+            "watch": false
           }
         },
         "lint": {

--- a/src/app/cores/interfaces/workflow.interfaces.ts
+++ b/src/app/cores/interfaces/workflow.interfaces.ts
@@ -1,7 +1,8 @@
 export type WorkflowName =
   | "single-prediction"
   | "de-novo-design"
-  | "interaction-screening";
+  | "interaction-screening"
+  | "bulk-prediction";
 export type WorkflowTool =
   | "alphafold2"
   | "bindcraft"

--- a/src/app/cores/interfaces/workflow.interfaces.ts
+++ b/src/app/cores/interfaces/workflow.interfaces.ts
@@ -1,5 +1,14 @@
-export type WorkflowName = "single-prediction" | "de-novo-design" | "interaction-screening";
-export type WorkflowTool = "alphafold2" | "bindcraft" | "boltz" | "boltzgen" | "colabfold" | "rfdiffusion";
+export type WorkflowName =
+  | "single-prediction"
+  | "de-novo-design"
+  | "interaction-screening";
+export type WorkflowTool =
+  | "alphafold2"
+  | "bindcraft"
+  | "boltz"
+  | "boltzgen"
+  | "colabfold"
+  | "rfdiffusion";
 
 /**
  * Workflow form data
@@ -86,7 +95,9 @@ export type SinglePredictionToolSettingsPayload = Partial<
 
 // de novo design payload includes fields that are loaded from the schema dynamically,
 // can't be specified fully
-export interface DeNovoDesignPayload extends DefaultWorkflowPayload, Record<string, unknown> {
+export interface DeNovoDesignPayload
+  extends DefaultWorkflowPayload,
+    Record<string, unknown> {
   id: string;
   sample_id: string;
   binder_name: string;
@@ -96,7 +107,6 @@ export type WorkflowFormData =
   | SinglePredictionPayload
   | DeNovoDesignPayload
   | InteractionScreeningPayload;
-
 
 /**
  * List runs response

--- a/src/app/cores/interfaces/workflow.interfaces.ts
+++ b/src/app/cores/interfaces/workflow.interfaces.ts
@@ -1,11 +1,15 @@
+export type WorkflowName = "single-prediction" | "de-novo-design" | "interaction-screening";
+export type WorkflowTool = "alphafold2" | "bindcraft" | "boltz" | "boltzgen" | "colabfold" | "rfdiffusion";
+
 /**
  * Workflow form data
  */
 export interface WorkflowLaunchForm {
-  tool: string;
+  workflow: WorkflowName;
+  tool: WorkflowTool;
   configProfiles?: string[];
   runName?: string;
-  paramsText?: string;
+  paramsText?: string | null;
 }
 
 /**
@@ -14,7 +18,7 @@ export interface WorkflowLaunchForm {
 export interface WorkflowLaunchPayload {
   launch: WorkflowLaunchForm;
   datasetId: string;
-  formData: Record<string, unknown>;
+  formData: WorkflowFormData;
 }
 
 /**
@@ -39,6 +43,60 @@ export interface RunInfo {
   startTime?: string;
   completeTime?: string;
 }
+
+export interface EntityRow {
+  id: string;
+  moleculeType: string;
+  copyNumber: number;
+  sequence: string;
+}
+
+export interface DefaultWorkflowPayload {
+  workflow: WorkflowName;
+  tool: WorkflowTool;
+  runName: string;
+  configProfiles?: string[];
+}
+
+// No extra fields currently required for interaction screening
+export type InteractionScreeningPayload = DefaultWorkflowPayload;
+
+export interface SinglePredictionPayload extends DefaultWorkflowPayload {
+  entities: EntityRow[];
+  fastaContent: string;
+  fastaFileUrl: string;
+  samplesheetId: string;
+  alphafold2_random_seed?: number;
+  alphafold2_full_dbs?: boolean;
+  colabfold_num_recycles?: number;
+  colabfold_use_templates?: boolean;
+  boltz_use_potentials?: boolean;
+}
+
+export type SinglePredictionToolSettingsPayload = Partial<
+  Pick<
+    SinglePredictionPayload,
+    | "alphafold2_random_seed"
+    | "alphafold2_full_dbs"
+    | "colabfold_num_recycles"
+    | "colabfold_use_templates"
+    | "boltz_use_potentials"
+  >
+>;
+
+// de novo design payload includes fields that are loaded from the schema dynamically,
+// can't be specified fully
+export interface DeNovoDesignPayload extends DefaultWorkflowPayload, Record<string, unknown> {
+  id: string;
+  sample_id: string;
+  binder_name: string;
+}
+
+export type WorkflowFormData =
+  | SinglePredictionPayload
+  | DeNovoDesignPayload
+  | InteractionScreeningPayload;
+
 
 /**
  * List runs response

--- a/src/app/cores/services/workflow-api.service.spec.ts
+++ b/src/app/cores/services/workflow-api.service.spec.ts
@@ -34,12 +34,17 @@ describe("WorkflowApiService", () => {
 
   it("should launch a workflow with launch config, form data, and dataset id", () => {
     const launch = {
-      tool: "ColabFold",
+      workflow: "interaction-screening" as const,
+      tool: "boltz" as const,
       configProfiles: ["singularity"],
       runName: "test-run",
       paramsText: null,
     };
-    const formData = { tool: "ColabFold", fastaContent: ">entity_1\nMKT" };
+    const formData = {
+      workflow: "interaction-screening" as const,
+      tool: "boltz" as const,
+      runName: "test-run",
+    };
 
     service
       .launchWorkflow(launch, formData, "dataset-1")

--- a/src/app/cores/services/workflow-api.service.ts
+++ b/src/app/cores/services/workflow-api.service.ts
@@ -2,6 +2,7 @@ import { HttpClient } from "@angular/common/http";
 import { inject, Injectable } from "@angular/core";
 import { Observable } from "rxjs";
 import {
+  WorkflowLaunchForm,
   WorkflowLaunchPayload,
   WorkflowLaunchResponse,
 } from "../interfaces/workflow.interfaces";
@@ -24,14 +25,9 @@ export class WorkflowApiService {
    * @param datasetId - Optional dataset ID to attach to the workflow
    */
   launchWorkflow(
-    launch: {
-      tool: string;
-      configProfiles?: string[];
-      runName?: string;
-      paramsText?: string | null;
-    },
-    formData: Record<string, unknown>,
-    datasetId: string
+      launch: WorkflowLaunchForm,
+      formData: WorkflowLaunchPayload["formData"],
+      datasetId: string
   ): Observable<WorkflowLaunchResponse> {
     const payload: WorkflowLaunchPayload = {
       launch,
@@ -39,8 +35,8 @@ export class WorkflowApiService {
       formData,
     };
     return this.http.post<WorkflowLaunchResponse>(
-      `${this.apiUrl}/launch`,
-      payload
+        `${this.apiUrl}/launch`,
+        payload
     );
   }
 }

--- a/src/app/cores/services/workflow-api.service.ts
+++ b/src/app/cores/services/workflow-api.service.ts
@@ -25,9 +25,9 @@ export class WorkflowApiService {
    * @param datasetId - Optional dataset ID to attach to the workflow
    */
   launchWorkflow(
-      launch: WorkflowLaunchForm,
-      formData: WorkflowLaunchPayload["formData"],
-      datasetId: string
+    launch: WorkflowLaunchForm,
+    formData: WorkflowLaunchPayload["formData"],
+    datasetId: string
   ): Observable<WorkflowLaunchResponse> {
     const payload: WorkflowLaunchPayload = {
       launch,
@@ -35,8 +35,8 @@ export class WorkflowApiService {
       formData,
     };
     return this.http.post<WorkflowLaunchResponse>(
-        `${this.apiUrl}/launch`,
-        payload
+      `${this.apiUrl}/launch`,
+      payload
     );
   }
 }

--- a/src/app/cores/services/workflow-submission.service.spec.ts
+++ b/src/app/cores/services/workflow-submission.service.spec.ts
@@ -1,6 +1,7 @@
 import { TestBed } from "@angular/core/testing";
 import { Router } from "@angular/router";
 import { of, throwError } from "rxjs";
+import { WorkflowFormData } from "../interfaces/workflow.interfaces";
 import { WorkflowApiService } from "./workflow-api.service";
 import { WorkflowSubmissionService } from "./workflow-submission.service";
 
@@ -8,6 +9,11 @@ describe("WorkflowSubmissionService", () => {
   let service: WorkflowSubmissionService;
   let workflowApiService: jasmine.SpyObj<WorkflowApiService>;
   let router: jasmine.SpyObj<Router>;
+  const minimalPayload: WorkflowFormData = {
+    workflow: "interaction-screening",
+    tool: "boltz",
+    runName: "test-run",
+  };
 
   beforeEach(() => {
     workflowApiService = jasmine.createSpyObj("WorkflowApiService", [
@@ -37,7 +43,7 @@ describe("WorkflowSubmissionService", () => {
   it("should require dataset id when submitting", () => {
     const onError = jasmine.createSpy("onError");
 
-    service.submitWorkflowWithDataset({ tool: "Boltz" }, undefined, onError);
+    service.submitWorkflowWithDataset(minimalPayload, undefined, onError);
 
     expect(onError).toHaveBeenCalled();
     expect(workflowApiService.launchWorkflow).not.toHaveBeenCalled();
@@ -47,7 +53,7 @@ describe("WorkflowSubmissionService", () => {
   it("should fall back to alert when dataset id is missing and no error handler is provided", () => {
     const alertSpy = spyOn(window, "alert");
 
-    service.submitWorkflowWithDataset({ tool: "Boltz" });
+    service.submitWorkflowWithDataset(minimalPayload);
 
     expect(alertSpy).toHaveBeenCalledWith(
       "Failed to launch workflow: datasetId is required to launch workflow."
@@ -65,7 +71,7 @@ describe("WorkflowSubmissionService", () => {
     );
 
     service.submitWorkflowWithDataset(
-      { tool: "AlphaFold2", configProfiles: ["docker"] },
+      { ...minimalPayload, configProfiles: ["docker"] },
       " dataset-123 "
     );
 
@@ -74,12 +80,13 @@ describe("WorkflowSubmissionService", () => {
       workflowApiService.launchWorkflow.calls.mostRecent().args;
     expect(datasetId).toBe("dataset-123");
     expect(formData).toEqual({
-      tool: "AlphaFold2",
+      ...minimalPayload,
       configProfiles: ["docker"],
     });
-    expect(launch.tool).toBe("AlphaFold2");
+    expect(launch.workflow).toBe("interaction-screening");
+    expect(launch.tool).toBe("boltz");
     expect(launch.configProfiles).toEqual(["docker"]);
-    expect(launch.runName).toContain("run-");
+    expect(launch.runName).toBe("test-run");
     expect(launch.paramsText).toBeNull();
     expect(service.isSubmitting()).toBeFalse();
     expect(service.showSuccessDialog()).toBeTrue();
@@ -99,10 +106,14 @@ describe("WorkflowSubmissionService", () => {
       })
     );
 
-    service.submitWorkflowWithDataset({}, "dataset-456");
+    service.submitWorkflowWithDataset(
+      { ...minimalPayload, runName: "" },
+      "dataset-456"
+    );
 
     const [launch] = workflowApiService.launchWorkflow.calls.mostRecent().args;
-    expect(launch.tool).toBe("BindCraft");
+    expect(launch.workflow).toBe("interaction-screening");
+    expect(launch.tool).toBe("boltz");
     expect(launch.configProfiles).toEqual(["singularity"]);
     expect(launch.runName).toContain("run-");
   });
@@ -114,7 +125,7 @@ describe("WorkflowSubmissionService", () => {
     );
 
     service.submitWorkflowWithDataset(
-      { tool: "Boltz" },
+      minimalPayload,
       "dataset-789",
       onError
     );
@@ -130,7 +141,7 @@ describe("WorkflowSubmissionService", () => {
       throwError(() => new Error("launch failed"))
     );
 
-    service.submitWorkflowWithDataset({ tool: "Boltz" }, "dataset-789");
+    service.submitWorkflowWithDataset(minimalPayload, "dataset-789");
 
     expect(alertSpy).toHaveBeenCalledWith(
       "Failed to launch workflow: launch failed"
@@ -143,7 +154,7 @@ describe("WorkflowSubmissionService", () => {
       throwError(() => ({ message: "" }))
     );
 
-    service.submitWorkflowWithDataset({ tool: "Boltz" }, "dataset-789");
+    service.submitWorkflowWithDataset(minimalPayload, "dataset-789");
 
     expect(alertSpy).toHaveBeenCalledWith(
       "Failed to launch workflow: Unknown error"

--- a/src/app/cores/services/workflow-submission.service.spec.ts
+++ b/src/app/cores/services/workflow-submission.service.spec.ts
@@ -124,11 +124,7 @@ describe("WorkflowSubmissionService", () => {
       throwError(() => new Error("launch failed"))
     );
 
-    service.submitWorkflowWithDataset(
-      minimalPayload,
-      "dataset-789",
-      onError
-    );
+    service.submitWorkflowWithDataset(minimalPayload, "dataset-789", onError);
 
     expect(onError).toHaveBeenCalledWith(jasmine.any(Error));
     expect(service.isSubmitting()).toBeFalse();

--- a/src/app/cores/services/workflow-submission.service.spec.ts
+++ b/src/app/cores/services/workflow-submission.service.spec.ts
@@ -54,18 +54,6 @@ describe("WorkflowSubmissionService", () => {
     );
   });
 
-  it("should delegate submitWorkflow to submitWorkflowWithDataset", () => {
-    const submitSpy = spyOn(service, "submitWorkflowWithDataset");
-
-    service.submitWorkflow({ tool: "ColabFold" });
-
-    expect(submitSpy).toHaveBeenCalledWith(
-      { tool: "ColabFold" },
-      undefined,
-      undefined
-    );
-  });
-
   it("should submit workflow with normalized dataset id and show success dialog", () => {
     workflowApiService.launchWorkflow.and.returnValue(
       of({

--- a/src/app/cores/services/workflow-submission.service.ts
+++ b/src/app/cores/services/workflow-submission.service.ts
@@ -5,7 +5,6 @@ import { WorkflowApiService } from "./workflow-api.service";
 import {
   WorkflowFormData,
   WorkflowLaunchForm,
-  WorkflowLaunchPayload
 } from "../interfaces/workflow.interfaces";
 
 @Injectable({

--- a/src/app/cores/services/workflow-submission.service.ts
+++ b/src/app/cores/services/workflow-submission.service.ts
@@ -2,6 +2,11 @@ import { inject, Injectable, signal } from "@angular/core";
 import { Router } from "@angular/router";
 import { getErrorMessage } from "../utils/error.utils";
 import { WorkflowApiService } from "./workflow-api.service";
+import {
+  WorkflowFormData,
+  WorkflowLaunchForm,
+  WorkflowLaunchPayload
+} from "../interfaces/workflow.interfaces";
 
 @Injectable({
   providedIn: "root",
@@ -22,7 +27,7 @@ export class WorkflowSubmissionService {
    * @param onError - Optional error handler
    */
   submitWorkflow(
-    formData: Record<string, unknown>,
+    formData: WorkflowLaunchPayload["formData"],
     onError?: (error: Error) => void
   ): void {
     this.submitWorkflowWithDataset(formData, undefined, onError);
@@ -35,7 +40,7 @@ export class WorkflowSubmissionService {
    * @param onError - Optional error handler
    */
   submitWorkflowWithDataset(
-    formData: Record<string, unknown>,
+    formData: WorkflowFormData,
     datasetId?: string,
     onError?: (error: Error) => void
   ): void {
@@ -48,11 +53,12 @@ export class WorkflowSubmissionService {
     const randomRunName = `run-${timestamp}-${randomStr}`;
 
     // Construct the launch configuration
-    const launch = {
-      tool: (formData.tool as string) || "BindCraft",
-      configProfiles: (formData.configProfiles as string[]) || ["singularity"],
-      runName: (formData.runName as string) || randomRunName,
-      paramsText: null as string | null,
+    const launch: WorkflowLaunchForm = {
+      workflow: formData.workflow,
+      tool: formData.tool,
+      configProfiles: formData.configProfiles ?? ["singularity"],
+      runName: formData.runName || randomRunName,
+      paramsText: null,
     };
 
     console.log("Submitting workflow with launch config:", launch);

--- a/src/app/cores/services/workflow-submission.service.ts
+++ b/src/app/cores/services/workflow-submission.service.ts
@@ -22,18 +22,6 @@ export class WorkflowSubmissionService {
   isSubmitting = signal<boolean>(false);
 
   /**
-   * Submit workflow with form data
-   * @param formData - The form data to submit
-   * @param onError - Optional error handler
-   */
-  submitWorkflow(
-    formData: WorkflowLaunchPayload["formData"],
-    onError?: (error: Error) => void
-  ): void {
-    this.submitWorkflowWithDataset(formData, undefined, onError);
-  }
-
-  /**
    * Submit workflow with form data and optional dataset ID
    * @param formData - The form data to submit
    * @param datasetId - Optional dataset ID to attach to the workflow

--- a/src/app/pages/workflow/de-novo-design/de-novo-design.ts
+++ b/src/app/pages/workflow/de-novo-design/de-novo-design.ts
@@ -41,7 +41,10 @@ import { SchemaLoaderService } from "../../../cores/services/schema-loader.servi
 import { WorkflowSubmissionService } from "../../../cores/services/workflow-submission.service";
 import { WORKFLOW_INPUT_DIRS } from "../../../cores/config/workflow-paths";
 import { getErrorMessage } from "../../../cores/utils/error.utils";
-import {DeNovoDesignPayload, WorkflowTool} from "../../../cores/interfaces/workflow.interfaces";
+import {
+  DeNovoDesignPayload,
+  WorkflowTool,
+} from "../../../cores/interfaces/workflow.interfaces";
 
 interface TabItem {
   id: "overview" | "output" | "papers";
@@ -701,7 +704,7 @@ export class DeNovoDesignComponent implements OnInit, OnDestroy {
                   error.message || "Unknown error"
                 }`
               );
-            },
+            }
           );
         },
         error: (error) => {

--- a/src/app/pages/workflow/de-novo-design/de-novo-design.ts
+++ b/src/app/pages/workflow/de-novo-design/de-novo-design.ts
@@ -41,6 +41,7 @@ import { SchemaLoaderService } from "../../../cores/services/schema-loader.servi
 import { WorkflowSubmissionService } from "../../../cores/services/workflow-submission.service";
 import { WORKFLOW_INPUT_DIRS } from "../../../cores/config/workflow-paths";
 import { getErrorMessage } from "../../../cores/utils/error.utils";
+import {DeNovoDesignPayload, WorkflowTool} from "../../../cores/interfaces/workflow.interfaces";
 
 interface TabItem {
   id: "overview" | "output" | "papers";
@@ -48,7 +49,7 @@ interface TabItem {
 }
 
 interface ToolChip extends ToolOption {
-  id: "bindcraft" | "boltzgen" | "rfdiffusion";
+  id: Extract<WorkflowTool, "bindcraft" | "boltzgen" | "rfdiffusion">;
 }
 
 type StepItem = Step;
@@ -680,9 +681,10 @@ export class DeNovoDesignComponent implements OnInit, OnDestroy {
             return;
           }
 
-          const workflowFormData = {
+          const workflowFormData: DeNovoDesignPayload = {
             ...formData,
-            tool: this.selectedToolLabel(),
+            workflow: "de-novo-design",
+            tool: this.selectedTool(),
           };
 
           this.workflowSubmission.submitWorkflowWithDataset(

--- a/src/app/pages/workflow/interaction-screening/interaction-screening.ts
+++ b/src/app/pages/workflow/interaction-screening/interaction-screening.ts
@@ -424,7 +424,7 @@ export class InteractionScreeningComponent {
             return;
           }
           this.workflowSubmission.submitWorkflowWithDataset(
-            { tool: this.selectedToolLabel(), runName: jobName },
+            { tool: this.selectedTool(), runName: jobName, workflow: "interaction-screening" },
             datasetId,
             (error) => {
               this.workflowSubmission.isSubmitting.set(false);

--- a/src/app/pages/workflow/interaction-screening/interaction-screening.ts
+++ b/src/app/pages/workflow/interaction-screening/interaction-screening.ts
@@ -424,7 +424,11 @@ export class InteractionScreeningComponent {
             return;
           }
           this.workflowSubmission.submitWorkflowWithDataset(
-            { tool: this.selectedTool(), runName: jobName, workflow: "interaction-screening" },
+            {
+              tool: this.selectedTool(),
+              runName: jobName,
+              workflow: "interaction-screening",
+            },
             datasetId,
             (error) => {
               this.workflowSubmission.isSubmitting.set(false);

--- a/src/app/pages/workflow/single-prediction/single-prediction.spec.ts
+++ b/src/app/pages/workflow/single-prediction/single-prediction.spec.ts
@@ -516,7 +516,7 @@ describe("SinglePredictionComponent", () => {
     expect(datasetUploadService.uploadDataset).toHaveBeenCalledWith(
       jasmine.objectContaining({
         formData: {
-          id: "single_prediction",
+          id: "single-prediction",
           fasta: MOCK_FASTA_RESPONSE.s3Uri,
         },
       })
@@ -529,12 +529,12 @@ describe("SinglePredictionComponent", () => {
       workflowSubmissionService.submitWorkflowWithDataset.calls.mostRecent()
         .args[0];
     expect(payload["runName"]).toBe("test-run");
-    expect(payload["mode"]).toBe("alphafold2");
+    expect(payload["tool"]).toBe("alphafold2");
     expect(payload["alphafold2_random_seed"]).toBe(42);
     expect(payload["alphafold2_full_dbs"]).toBe(true);
     expect(payload["fastaContent"]).toContain(">pro_1");
     expect(payload["fastaFileUrl"]).toBe(MOCK_FASTA_RESPONSE.s3Uri);
-    expect(payload["samplesheetId"]).toBe("single_prediction");
+    expect(payload["samplesheetId"]).toBe("single-prediction");
     expect(component.canSubmit()).toBe(true);
   });
 

--- a/src/app/pages/workflow/single-prediction/single-prediction.ts
+++ b/src/app/pages/workflow/single-prediction/single-prediction.ts
@@ -56,7 +56,10 @@ interface TabItem {
 }
 
 type MoleculeType = "protein" | "rna" | "dna" | "ligand" | "ccd";
-type SinglePredictionTool = Extract<WorkflowTool, "colabfold" | "alphafold2" | "boltz">;
+type SinglePredictionTool = Extract<
+  WorkflowTool,
+  "colabfold" | "alphafold2" | "boltz"
+>;
 type StepItem = Step;
 
 interface ToolChip extends ToolOption {
@@ -869,11 +872,14 @@ export class SinglePredictionComponent {
         this.showError(
           `Workflow launch failed: ${error.message || "Unknown error"}`
         );
-      },
+      }
     );
   }
 
-  private buildWorkflowPayload(): Omit<SinglePredictionPayload, "fastaFileUrl" | "samplesheetId"> {
+  private buildWorkflowPayload(): Omit<
+    SinglePredictionPayload,
+    "fastaFileUrl" | "samplesheetId"
+  > {
     return {
       workflow: "single-prediction",
       tool: this.selectedTool(),

--- a/src/app/pages/workflow/single-prediction/single-prediction.ts
+++ b/src/app/pages/workflow/single-prediction/single-prediction.ts
@@ -44,6 +44,11 @@ import {
   validateProteinSequence,
   validateRnaSequence,
 } from "../../../cores/utils/fasta.utils";
+import {
+  SinglePredictionPayload,
+  SinglePredictionToolSettingsPayload,
+  WorkflowTool,
+} from "../../../cores/interfaces/workflow.interfaces";
 
 interface TabItem {
   id: "overview" | "output" | "papers";
@@ -51,11 +56,11 @@ interface TabItem {
 }
 
 type MoleculeType = "protein" | "rna" | "dna" | "ligand" | "ccd";
-type ToolId = "colabfold" | "alphafold2" | "boltz";
+type SinglePredictionTool = Extract<WorkflowTool, "colabfold" | "alphafold2" | "boltz">;
 type StepItem = Step;
 
 interface ToolChip extends ToolOption {
-  id: ToolId;
+  id: SinglePredictionTool;
 }
 
 interface EntityRow {
@@ -114,7 +119,7 @@ export class SinglePredictionComponent {
     CCD_COMPOUNDS
   ).map(([code, name]) => ({ value: code, label: `${code} - ${name}` }));
 
-  private readonly samplesheetId = "single_prediction";
+  private readonly samplesheetId = "single-prediction";
   private nextRowId = 1;
   ccdLookupState = signal<Record<number, "idle" | "valid" | "invalid">>({});
   ccdLookupNames = signal<Record<number, string>>({}); // compound name resolved from the local CCD dictionary via lookupCcdCompound()
@@ -140,7 +145,7 @@ export class SinglePredictionComponent {
     { id: "boltz", label: "Boltz" },
   ];
   isToolAvailable = signal(true);
-  selectedTool = signal<ToolId>("colabfold");
+  selectedTool = signal<SinglePredictionTool>("colabfold");
   selectedToolLabel: Signal<string> = computed(
     () =>
       this.tools.find((tool) => tool.id === this.selectedTool())?.label ?? ""
@@ -281,7 +286,7 @@ export class SinglePredictionComponent {
     this.activeTab.set(id);
   }
 
-  selectTool(id: ToolId) {
+  selectTool(id: SinglePredictionTool) {
     this.selectedTool.set(id);
   }
 
@@ -729,7 +734,7 @@ export class SinglePredictionComponent {
     return {};
   }
 
-  private buildToolSettingsPayload(): Record<string, unknown> {
+  private buildToolSettingsPayload(): SinglePredictionToolSettingsPayload {
     switch (this.selectedTool()) {
       case "alphafold2":
         return {
@@ -868,11 +873,11 @@ export class SinglePredictionComponent {
     );
   }
 
-  private buildWorkflowPayload(): Record<string, unknown> {
+  private buildWorkflowPayload(): Omit<SinglePredictionPayload, "fastaFileUrl" | "samplesheetId"> {
     return {
-      tool: "Proteinfold",
+      workflow: "single-prediction",
+      tool: this.selectedTool(),
       runName: this.jobName().trim(),
-      mode: this.selectedTool(),
       entities: this.entityRows().map((row, index) => ({
         id: `entity_${index + 1}`,
         moleculeType: row.moleculeType,


### PR DESCRIPTION
<!--
Thank you for contributing! Please fill out the sections below to help maintainers review your change faster.
Delete any sections that don't apply.
-->

# Pull Request

## Summary

Workflow and tool names are currently confusing, and not clearly specified in either the backend or frontend code. Try to define them explicitly and make sure they're used consistently when submitting workflow data.

This will require a matching PR on the backend (TBD)

## Changes

- Define `WorkflowName` and `WorkflowTool`
- Try to define explicit types for submitted workflow payloads

## How to Test

Run `ng test`

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added or updated documentation where necessary
- [x] I have run linting and unit tests locally
- [x] The code follows the project's style guidelines
