### PR TITLE
fix: sample ID handling

### DIFF
--- a/src/app/cores/interfaces/workflow.interfaces.ts
+++ b/src/app/cores/interfaces/workflow.interfaces.ts
@@ -76,7 +76,6 @@ export interface SinglePredictionPayload extends DefaultWorkflowPayload {
   entities: EntityRow[];
   fastaContent: string;
   fastaFileUrl: string;
-  samplesheetId: string;
   alphafold2_random_seed?: number;
   alphafold2_full_dbs?: boolean;
   colabfold_num_recycles?: number;

--- a/src/app/cores/interfaces/workflow.interfaces.ts
+++ b/src/app/cores/interfaces/workflow.interfaces.ts
@@ -66,6 +66,7 @@ export interface DefaultWorkflowPayload {
   tool: WorkflowTool;
   runName: string;
   configProfiles?: string[];
+  sample_id: string;
 }
 
 // No extra fields currently required for interaction screening
@@ -100,7 +101,6 @@ export interface DeNovoDesignPayload
   extends DefaultWorkflowPayload,
     Record<string, unknown> {
   id: string;
-  sample_id: string;
   binder_name: string;
 }
 

--- a/src/app/cores/services/workflow-api.service.spec.ts
+++ b/src/app/cores/services/workflow-api.service.spec.ts
@@ -44,6 +44,7 @@ describe("WorkflowApiService", () => {
       workflow: "interaction-screening" as const,
       tool: "boltz" as const,
       runName: "test-run",
+      sample_id: "test-run",
     };
 
     service

--- a/src/app/cores/services/workflow-submission.service.spec.ts
+++ b/src/app/cores/services/workflow-submission.service.spec.ts
@@ -13,6 +13,7 @@ describe("WorkflowSubmissionService", () => {
     workflow: "interaction-screening",
     tool: "boltz",
     runName: "test-run",
+    sample_id: "test-run",
   };
 
   beforeEach(() => {

--- a/src/app/pages/workflow/interaction-screening/interaction-screening.spec.ts
+++ b/src/app/pages/workflow/interaction-screening/interaction-screening.spec.ts
@@ -159,6 +159,23 @@ describe("InteractionScreeningComponent", () => {
     expect(workflowSubmissionService.isSubmitting()).toBe(false);
   });
 
+  it("should submit sample_id matching the uploaded dataset runId", () => {
+    fillValidForm();
+    fixture.detectChanges();
+
+    component.submitWorkflow();
+
+    const datasetUploadRequest =
+      datasetUploadService.uploadInteractionScreeningDataset.calls.mostRecent()
+        .args[0];
+    expect(datasetUploadRequest.runId).toBe("my-job");
+
+    const payload =
+      workflowSubmissionService.submitWorkflowWithDataset.calls.mostRecent()
+        .args[0];
+    expect(payload["sample_id"]).toBe(datasetUploadRequest.runId);
+  });
+
   it("should show error alert and set isSubmitting false when upload throws", () => {
     fillValidForm();
     fixture.detectChanges();

--- a/src/app/pages/workflow/interaction-screening/interaction-screening.ts
+++ b/src/app/pages/workflow/interaction-screening/interaction-screening.ts
@@ -428,6 +428,7 @@ export class InteractionScreeningComponent {
               tool: this.selectedTool(),
               runName: jobName,
               workflow: "interaction-screening",
+              sample_id: jobName,
             },
             datasetId,
             (error) => {

--- a/src/app/pages/workflow/single-prediction/single-prediction.spec.ts
+++ b/src/app/pages/workflow/single-prediction/single-prediction.spec.ts
@@ -513,13 +513,12 @@ describe("SinglePredictionComponent", () => {
     component.submitWorkflow();
 
     expect(fastaUploadService.uploadFastaFile).toHaveBeenCalled();
-    expect(datasetUploadService.uploadDataset).toHaveBeenCalledWith(
-      jasmine.objectContaining({
-        formData: {
-          id: "single-prediction",
-          fasta: MOCK_FASTA_RESPONSE.s3Uri,
-        },
-      })
+    const datasetUploadRequest =
+      datasetUploadService.uploadDataset.calls.mostRecent().args[0];
+    const samplesheetId = datasetUploadRequest.formData["id"];
+    expect(samplesheetId).toMatch(/^single-prediction-[a-z0-9]{8}$/);
+    expect(datasetUploadRequest.formData["fasta"]).toBe(
+      MOCK_FASTA_RESPONSE.s3Uri
     );
     expect(
       workflowSubmissionService.submitWorkflowWithDataset
@@ -534,7 +533,7 @@ describe("SinglePredictionComponent", () => {
     expect(payload["alphafold2_full_dbs"]).toBe(true);
     expect(payload["fastaContent"]).toContain(">pro_1");
     expect(payload["fastaFileUrl"]).toBe(MOCK_FASTA_RESPONSE.s3Uri);
-    expect(payload["samplesheetId"]).toBe("single-prediction");
+    expect(payload["sample_id"]).toBe(samplesheetId);
     expect(component.canSubmit()).toBe(true);
   });
 

--- a/src/app/pages/workflow/single-prediction/single-prediction.ts
+++ b/src/app/pages/workflow/single-prediction/single-prediction.ts
@@ -122,7 +122,7 @@ export class SinglePredictionComponent {
     CCD_COMPOUNDS
   ).map(([code, name]) => ({ value: code, label: `${code} - ${name}` }));
 
-  private readonly samplesheetId = "single-prediction";
+  private readonly samplesheetId = `single-prediction-${this.generateRandomSuffix()}`;
   private nextRowId = 1;
   ccdLookupState = signal<Record<number, "idle" | "valid" | "invalid">>({});
   ccdLookupNames = signal<Record<number, string>>({}); // compound name resolved from the local CCD dictionary via lookupCcdCompound()
@@ -864,7 +864,7 @@ export class SinglePredictionComponent {
       {
         ...this.buildWorkflowPayload(),
         fastaFileUrl: fastaUrl,
-        samplesheetId: this.samplesheetId,
+        sample_id: this.samplesheetId,
       },
       datasetId,
       (error) => {
@@ -876,9 +876,16 @@ export class SinglePredictionComponent {
     );
   }
 
+  private generateRandomSuffix(): string {
+    return (
+      globalThis.crypto?.randomUUID?.().replace(/-/g, "") ??
+      Math.random().toString(36).slice(2)
+    ).slice(0, 8);
+  }
+
   private buildWorkflowPayload(): Omit<
     SinglePredictionPayload,
-    "fastaFileUrl" | "samplesheetId"
+    "fastaFileUrl" | "sample_id"
   > {
     return {
       workflow: "single-prediction",


### PR DESCRIPTION
# Pull Request

## Summary

[SBP-366](https://biocloud.atlassian.net/browse/SBP-366): sample IDs are used to identify results, and in my previous PR I didn't do enough to make them consistent. Make `sample_id` a standard field submitted by all workflows, so the backend can record and use it consistently.

I'll also update the backend to reflect this change.

## Changes

- Add `sample_id` as a standard field in workflow form data
- Update workflows to submit `sample_id`

## How to Test

Run `ng test`

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added or updated documentation where necessary
- [x] I have run linting and unit tests locally
- [x] The code follows the project's style guidelines


[SBP-366]: https://biocloud.atlassian.net/browse/SBP-366?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ