### PR TITLE
fix: set outputHashing so users don't get cached versions

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -55,6 +55,7 @@
             "production": {
               "optimization": true,
               "sourceMap": false,
+              "outputHashing": "bundles",
               "budgets": [
                 {
                   "type": "initial",


### PR DESCRIPTION
# Pull Request

## Summary

Setting `outputHashing: "bundles"` means users won't get cached versions of the site code

## Changes

- Set `outputHashing: "bundles"` in the angular build config

## How to Test

N/A

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
