### PR TITLE
fix: remove unused boltzgen

### DIFF
--- a/src/app/cores/interfaces/workflow.interfaces.ts
+++ b/src/app/cores/interfaces/workflow.interfaces.ts
@@ -7,7 +7,6 @@ export type WorkflowTool =
   | "alphafold2"
   | "bindcraft"
   | "boltz"
-  | "boltzgen"
   | "colabfold"
   | "rfdiffusion";
 

--- a/src/app/pages/workflow/de-novo-design/de-novo-design.ts
+++ b/src/app/pages/workflow/de-novo-design/de-novo-design.ts
@@ -52,7 +52,7 @@ interface TabItem {
 }
 
 interface ToolChip extends ToolOption {
-  id: Extract<WorkflowTool, "bindcraft" | "boltzgen" | "rfdiffusion">;
+  id: Extract<WorkflowTool, "bindcraft" | "rfdiffusion">;
 }
 
 type StepItem = Step;
@@ -134,10 +134,6 @@ export default class DeNovoDesignComponent implements OnInit, OnDestroy {
   // Tools
   readonly tools: ToolChip[] = [
     {
-      id: "boltzgen",
-      label: "BoltzGen",
-    },
-    {
       id: "rfdiffusion",
       label: "RFDiffusion",
     },
@@ -173,7 +169,6 @@ export default class DeNovoDesignComponent implements OnInit, OnDestroy {
     ToolChip["id"],
     { name: string; label: string; description?: string }[]
   > = {
-    boltzgen: [],
     rfdiffusion: [],
     bindcraft: [],
   };


### PR DESCRIPTION
<!--
Thank you for contributing! Please fill out the sections below to help maintainers review your change faster.
Delete any sections that don't apply.
-->

# Pull Request

## Summary

Removal of all references to Boltzgen, related pull request in the backend is completed https://github.com/AustralianBioCommons/sbp-backend/pull/77/changes.

## Changes

- `de-novo-design.ts` — removed the BoltzGen entry from the tool selector, the toolParams entry, and dropped "boltzgen" from the ToolChip id type. (The "temporarily unavailable" message now lists only RFDiffusion.)
- `themes.config.ts`— removed the BoltzGen tool from the Binder Design theme.
- `workflow.interfaces.ts`— removed "boltzgen" from the WorkflowTool type.
- `binder-design.spec.ts` — removed the BoltzGen test case and the `navigateToTool("boltzgen")` assertion.

## How to Test

All tests shall pass

<img width="1508" height="554" alt="Screenshot 2026-06-12 at 10 16 53 am" src="https://github.com/user-attachments/assets/549bfcf7-2c41-47ea-a82b-b1f910dc028d" />


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added or updated documentation where necessary
- [x] I have run linting and unit tests locally
- [x] The code follows the project's style guidelines
