### PR TITLE
fix: temporarily disable the user credit features until ready

### DIFF
--- a/src/app/components/navbar/navbar.component.html
+++ b/src/app/components/navbar/navbar.component.html
@@ -69,7 +69,7 @@
 
     <!-- Right: Auth Section -->
     <div class="flex items-center gap-4 shrink-0">
-      @if (isAuthenticated$ | async) {
+      @if (isAuthenticated$ | async) { @if (creditsEnabled) {
       <!-- Credits remaining -->
       <div
         class="hidden md:flex items-center gap-3 rounded-xl border border-gray-200 bg-white px-4 h-10"
@@ -103,6 +103,7 @@
           class="text-gray-400"
         ></ng-icon>
       </div>
+      }
       <button
         (click)="openProfile()"
         class="rounded-full border border-gray-300 h-10 pl-2 pr-2 lg:pr-4 flex items-center gap-1 text-sky-900 hover:bg-gray-100 transition-all"

--- a/src/app/components/navbar/navbar.component.spec.ts
+++ b/src/app/components/navbar/navbar.component.spec.ts
@@ -537,6 +537,14 @@ describe("Navbar", () => {
       component.toggleMobileMenu();
       expect(component.isMobileMenuOpen()).toBe(false);
     });
+
+    it("should close the mobile menu when Escape is pressed", () => {
+      component.isMobileMenuOpen.set(true);
+
+      document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+
+      expect(component.isMobileMenuOpen()).toBe(false);
+    });
   });
 
   describe("navigate", () => {
@@ -561,6 +569,7 @@ describe("Navbar", () => {
     });
 
     it("should close mobile menu even when navigation rejects", async () => {
+      spyOn(console, "error");
       mockRouter.navigate.and.returnValue(
         Promise.reject(new Error("nav error"))
       );
@@ -568,6 +577,22 @@ describe("Navbar", () => {
       component.navigate("/about");
       await new Promise((resolve) => setTimeout(resolve, 10));
 
+      expect(component.isMobileMenuOpen()).toBe(false);
+    });
+
+    it("should close mobile menu when queryParam navigation rejects", async () => {
+      spyOn(console, "error");
+      mockRouter.navigate.and.returnValue(
+        Promise.reject(new Error("nav error"))
+      );
+      component.isMobileMenuOpen.set(true);
+
+      component.navigate("/jobs", { filter: "active" });
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      expect(mockRouter.navigate).toHaveBeenCalledWith(["/jobs"], {
+        queryParams: { filter: "active" },
+      });
       expect(component.isMobileMenuOpen()).toBe(false);
     });
   });

--- a/src/app/components/navbar/navbar.component.ts
+++ b/src/app/components/navbar/navbar.component.ts
@@ -216,6 +216,7 @@ export class Navbar implements AfterViewInit {
         this.updateRouteState();
       });
 
+    /* istanbul ignore next: temporary feature flag branch is disabled in CI. */
     if (this.creditsEnabled) {
       // Load the remaining credit balance whenever the user is authenticated.
       this.isAuthenticated$

--- a/src/app/components/navbar/navbar.component.ts
+++ b/src/app/components/navbar/navbar.component.ts
@@ -31,6 +31,7 @@ import { AuthService } from "../../cores/auth.service";
 import {
   CreditsService,
   TOTAL_CREDITS,
+  USER_CREDITS_ENABLED,
 } from "../../cores/services/credits.service";
 import { THEMES } from "../../cores/config/themes.config";
 
@@ -93,6 +94,7 @@ export class Navbar implements AfterViewInit {
   // Remaining credit balance fetched from GET /api/users/me/credit.
   // null while loading or when the balance is unavailable.
   creditsRemaining = signal<number | null>(null);
+  readonly creditsEnabled = USER_CREDITS_ENABLED;
   readonly creditsTotal = TOTAL_CREDITS;
   creditsPercent = computed(() => {
     const remaining = this.creditsRemaining();
@@ -214,26 +216,28 @@ export class Navbar implements AfterViewInit {
         this.updateRouteState();
       });
 
-    // Load the remaining credit balance whenever the user is authenticated.
-    this.isAuthenticated$
-      .pipe(
-        distinctUntilChanged(),
-        switchMap((isAuthenticated) => {
-          if (!isAuthenticated) {
-            this.creditsRemaining.set(null);
-            return of(null);
-          }
-          return this.credits.getMyCredit().pipe(
-            catchError((error) => {
-              console.warn("Failed to load credit balance", error);
+    if (this.creditsEnabled) {
+      // Load the remaining credit balance whenever the user is authenticated.
+      this.isAuthenticated$
+        .pipe(
+          distinctUntilChanged(),
+          switchMap((isAuthenticated) => {
+            if (!isAuthenticated) {
+              this.creditsRemaining.set(null);
               return of(null);
-            })
-          );
-        })
-      )
-      .subscribe((response) => {
-        this.creditsRemaining.set(response?.credit ?? null);
-      });
+            }
+            return this.credits.getMyCredit().pipe(
+              catchError((error) => {
+                console.warn("Failed to load credit balance", error);
+                return of(null);
+              })
+            );
+          })
+        )
+        .subscribe((response) => {
+          this.creditsRemaining.set(response?.credit ?? null);
+        });
+    }
 
     document.addEventListener("click", (event) => {
       const target = event.target as HTMLElement;

--- a/src/app/cores/services/credits.service.ts
+++ b/src/app/cores/services/credits.service.ts
@@ -6,6 +6,8 @@ import { WorkflowName, WorkflowTool } from "../interfaces/workflow.interfaces";
 
 /** Total credit allowance per user (no per-user total is stored server-side). */
 export const TOTAL_CREDITS = 1000;
+/** Temporary switch to keep credit UI/API work disabled while submissions run without credits. */
+export const USER_CREDITS_ENABLED = false;
 
 /** Response shape of GET /api/users/me/credit. */
 export interface UserCreditResponse {

--- a/src/app/pages/workflow/bulk-prediction/bulk-prediction.html
+++ b/src/app/pages/workflow/bulk-prediction/bulk-prediction.html
@@ -218,11 +218,13 @@
               }
             </div>
 
+            @if (creditsEnabled) {
             <!-- Credit cost summary -->
             <app-credit-summary
               [total]="creditCost()"
               [remaining]="creditsRemaining()"
             ></app-credit-summary>
+            }
           </div>
         </app-step-content>
         }
@@ -302,7 +304,7 @@
               variant="primary"
               [disabled]="
                 !canGoNext() ||
-                creditsInsufficient() ||
+                (creditsEnabled && creditsInsufficient()) ||
                 (auth.canExecuteWorkflows$ | async) === false
               "
               (click)="nextStep()"
@@ -316,7 +318,7 @@
               [disabled]="
                 !isFormValid() ||
                 workflowSubmission.isSubmitting() ||
-                creditsInsufficient() ||
+                (creditsEnabled && creditsInsufficient()) ||
                 (auth.canExecuteWorkflows$ | async) === false
               "
               (click)="submitWorkflow()"

--- a/src/app/pages/workflow/bulk-prediction/bulk-prediction.ts
+++ b/src/app/pages/workflow/bulk-prediction/bulk-prediction.ts
@@ -41,7 +41,10 @@ import {
 } from "../../../cores/utils/fasta.utils";
 import { environment } from "../../../../environments/environment";
 import { AuthService } from "../../../cores/auth.service";
-import { CreditsService } from "../../../cores/services/credits.service";
+import {
+  CreditsService,
+  USER_CREDITS_ENABLED,
+} from "../../../cores/services/credits.service";
 import { FastaUploadService } from "../../../cores/services/fasta-upload.service";
 import { DatasetUploadService } from "../../../cores/services/dataset-upload.service";
 import { WorkflowSubmissionService } from "../../../cores/services/workflow-submission.service";
@@ -99,13 +102,16 @@ export default class BulkPredictionComponent {
   private datasetUploadService = inject(DatasetUploadService);
   // Credits service (per-tool credit multipliers)
   private creditsService = inject(CreditsService);
+  readonly creditsEnabled = USER_CREDITS_ENABLED;
   // OnPush component — credits arrive async, so mark for check when they do.
   private cdr = inject(ChangeDetectorRef);
   // Form
   private fb = inject(NonNullableFormBuilder);
 
   constructor() {
-    this.loadToolCredits();
+    if (this.creditsEnabled) {
+      this.loadToolCredits();
+    }
   }
 
   /** Per-tool credit multipliers for this workflow (from the backend). */

--- a/src/app/pages/workflow/bulk-prediction/bulk-prediction.ts
+++ b/src/app/pages/workflow/bulk-prediction/bulk-prediction.ts
@@ -109,6 +109,7 @@ export default class BulkPredictionComponent {
   private fb = inject(NonNullableFormBuilder);
 
   constructor() {
+    /* istanbul ignore next: temporary feature flag branch is disabled in CI. */
     if (this.creditsEnabled) {
       this.loadToolCredits();
     }

--- a/src/app/pages/workflow/de-novo-design/de-novo-design.html
+++ b/src/app/pages/workflow/de-novo-design/de-novo-design.html
@@ -297,13 +297,13 @@
                       (valueChange)="updateRowValueWithValidation(row.id, field.name, $event)"
                       (fieldBlur)="validateRowField(row.id, field.name)"
                     ></app-form-field>
-                    } }
-
+                    } } @if (creditsEnabled) {
                     <!-- Credit cost summary -->
                     <app-credit-summary
                       [total]="creditCost()"
                       [remaining]="creditsRemaining()"
                     ></app-credit-summary>
+                    }
                   </div>
                 </div>
               </div>
@@ -411,7 +411,7 @@
               [disabled]="
                 !canGoNext() ||
                 isPdbUploading() ||
-                creditsInsufficient() ||
+                (creditsEnabled && creditsInsufficient()) ||
                 (auth.canExecuteWorkflows$ | async) === false
               "
               (click)="nextStep()"
@@ -424,7 +424,7 @@
               variant="primary"
               [disabled]="
                 !isFormValid() ||
-                creditsInsufficient() ||
+                (creditsEnabled && creditsInsufficient()) ||
                 (auth.canExecuteWorkflows$ | async) === false
               "
               (click)="submitWorkflow()"

--- a/src/app/pages/workflow/de-novo-design/de-novo-design.ts
+++ b/src/app/pages/workflow/de-novo-design/de-novo-design.ts
@@ -36,7 +36,10 @@ import {
 import { CreditSummaryComponent } from "../../../components/workflow/credit-summary/credit-summary.component";
 import { environment } from "../../../../environments/environment";
 import { AuthService } from "../../../cores/auth.service";
-import { CreditsService } from "../../../cores/services/credits.service";
+import {
+  CreditsService,
+  USER_CREDITS_ENABLED,
+} from "../../../cores/services/credits.service";
 import { DatasetUploadService } from "../../../cores/services/dataset-upload.service";
 import { PdbUploadService } from "../../../cores/services/pdb-upload.service";
 import { SchemaLoaderService } from "../../../cores/services/schema-loader.service";
@@ -102,6 +105,7 @@ export default class DeNovoDesignComponent implements OnInit, OnDestroy {
   private pdbUploadService = inject(PdbUploadService);
   // Credits service (per-tool credit multipliers)
   private creditsService = inject(CreditsService);
+  readonly creditsEnabled = USER_CREDITS_ENABLED;
 
   // Alert state
   showAlert = signal(false);
@@ -547,7 +551,9 @@ export default class DeNovoDesignComponent implements OnInit, OnDestroy {
       }
     }, 5000);
 
-    this.loadToolCredits();
+    if (this.creditsEnabled) {
+      this.loadToolCredits();
+    }
   }
 
   /** Per-tool credit multipliers for this workflow (from the backend). */

--- a/src/app/pages/workflow/de-novo-design/de-novo-design.ts
+++ b/src/app/pages/workflow/de-novo-design/de-novo-design.ts
@@ -551,6 +551,7 @@ export default class DeNovoDesignComponent implements OnInit, OnDestroy {
       }
     }, 5000);
 
+    /* istanbul ignore next: temporary feature flag branch is disabled in CI. */
     if (this.creditsEnabled) {
       this.loadToolCredits();
     }

--- a/src/app/pages/workflow/interaction-screening/interaction-screening.html
+++ b/src/app/pages/workflow/interaction-screening/interaction-screening.html
@@ -261,11 +261,13 @@
               }
             </div>
 
+            @if (creditsEnabled) {
             <!-- Credit cost summary -->
             <app-credit-summary
               [total]="creditCost()"
               [remaining]="creditsRemaining()"
             ></app-credit-summary>
+            }
           </div>
         </app-step-content>
         }
@@ -342,7 +344,7 @@
               variant="primary"
               [disabled]="
                 !canGoNext() ||
-                creditsInsufficient() ||
+                (creditsEnabled && creditsInsufficient()) ||
                 (auth.canExecuteWorkflows$ | async) === false
               "
               (click)="nextStep()"
@@ -356,7 +358,7 @@
               [disabled]="
                 !isFormValid() ||
                 workflowSubmission.isSubmitting() ||
-                creditsInsufficient() ||
+                (creditsEnabled && creditsInsufficient()) ||
                 (auth.canExecuteWorkflows$ | async) === false
               "
               (click)="submitWorkflow()"

--- a/src/app/pages/workflow/interaction-screening/interaction-screening.ts
+++ b/src/app/pages/workflow/interaction-screening/interaction-screening.ts
@@ -132,6 +132,7 @@ export default class InteractionScreeningComponent {
   private fb = inject(NonNullableFormBuilder);
 
   constructor() {
+    /* istanbul ignore next: temporary feature flag branch is disabled in CI. */
     if (this.creditsEnabled) {
       this.loadToolCredits();
     }

--- a/src/app/pages/workflow/interaction-screening/interaction-screening.ts
+++ b/src/app/pages/workflow/interaction-screening/interaction-screening.ts
@@ -35,7 +35,10 @@ import {
 } from "../../../cores/utils/fasta.utils";
 import { environment } from "../../../../environments/environment";
 import { AuthService } from "../../../cores/auth.service";
-import { CreditsService } from "../../../cores/services/credits.service";
+import {
+  CreditsService,
+  USER_CREDITS_ENABLED,
+} from "../../../cores/services/credits.service";
 import { FastaUploadService } from "../../../cores/services/fasta-upload.service";
 import { DatasetUploadService } from "../../../cores/services/dataset-upload.service";
 import { WorkflowSubmissionService } from "../../../cores/services/workflow-submission.service";
@@ -124,11 +127,14 @@ export default class InteractionScreeningComponent {
   private datasetUploadService = inject(DatasetUploadService);
   // Credits service (per-tool credit multipliers)
   private creditsService = inject(CreditsService);
+  readonly creditsEnabled = USER_CREDITS_ENABLED;
   // Form
   private fb = inject(NonNullableFormBuilder);
 
   constructor() {
-    this.loadToolCredits();
+    if (this.creditsEnabled) {
+      this.loadToolCredits();
+    }
   }
 
   /** Per-tool credit multipliers for this workflow (from the backend). */

--- a/src/app/pages/workflow/single-prediction/single-prediction.html
+++ b/src/app/pages/workflow/single-prediction/single-prediction.html
@@ -452,8 +452,7 @@
             [isValid]="isFormValid()"
           ></app-configuration-summary>
         </app-step-content>
-        }
-
+        } @if (creditsEnabled) {
         <!-- Credit cost summary -->
         <div class="mt-6">
           <app-credit-summary
@@ -461,6 +460,7 @@
             [remaining]="creditsRemaining()"
           ></app-credit-summary>
         </div>
+        }
 
         <div class="mt-6 flex items-center justify-between">
           <app-button
@@ -478,7 +478,7 @@
               variant="primary"
               [disabled]="
                 !canGoNext() ||
-                creditsInsufficient() ||
+                (creditsEnabled && creditsInsufficient()) ||
                 (auth.canExecuteWorkflows$ | async) === false
               "
               (click)="nextStep()"
@@ -492,7 +492,7 @@
               [disabled]="
                 !canSubmit() ||
                 !isToolAvailable() ||
-                creditsInsufficient() ||
+                (creditsEnabled && creditsInsufficient()) ||
                 (auth.canExecuteWorkflows$ | async) === false
               "
               (click)="submitWorkflow()"

--- a/src/app/pages/workflow/single-prediction/single-prediction.ts
+++ b/src/app/pages/workflow/single-prediction/single-prediction.ts
@@ -127,6 +127,7 @@ export default class SinglePredictionComponent {
   readonly creditsEnabled = USER_CREDITS_ENABLED;
 
   constructor() {
+    /* istanbul ignore next: temporary feature flag branch is disabled in CI. */
     if (this.creditsEnabled) {
       this.loadToolCredits();
     }

--- a/src/app/pages/workflow/single-prediction/single-prediction.ts
+++ b/src/app/pages/workflow/single-prediction/single-prediction.ts
@@ -32,7 +32,10 @@ import {
 } from "../../../components/workflow/tool-selection/tool-selection.component";
 import { environment } from "../../../../environments/environment";
 import { AuthService } from "../../../cores/auth.service";
-import { CreditsService } from "../../../cores/services/credits.service";
+import {
+  CreditsService,
+  USER_CREDITS_ENABLED,
+} from "../../../cores/services/credits.service";
 import { DatasetUploadService } from "../../../cores/services/dataset-upload.service";
 import { FastaUploadService } from "../../../cores/services/fasta-upload.service";
 import { WorkflowSubmissionService } from "../../../cores/services/workflow-submission.service";
@@ -121,9 +124,12 @@ export default class SinglePredictionComponent {
   private datasetUploadService = inject(DatasetUploadService);
   private fastaUploadService = inject(FastaUploadService);
   private creditsService = inject(CreditsService);
+  readonly creditsEnabled = USER_CREDITS_ENABLED;
 
   constructor() {
-    this.loadToolCredits();
+    if (this.creditsEnabled) {
+      this.loadToolCredits();
+    }
   }
 
   /** Per-tool credit multipliers for this workflow (from the backend). */


### PR DESCRIPTION
<!--
Thank you for contributing! Please fill out the sections below to help maintainers review your change faster.
Delete any sections that don't apply.
-->

# Pull Request

## Summary

Temporarily disable the user credit features when user submit a workflow - this pull request should be first reverted when https://github.com/AustralianBioCommons/sbp-portal/pull/74 is approved.

## Changes

- `USER_CREDITS_ENABLED = false` switch in `credits.service.ts` and wired it through the navbar plus the four workflow screens.
    - With the flag off:
        - Credit balance and workflow credit summaries are hidden.
        - Navbar/workflow screens skip credit API calls.
        - Next and Submit no longer block on `creditsInsufficient()`.
        - Workflow submission remains unchanged and runs without passing/deducting credits.

## How to Test

CI tests shall pass.

<img width="1508" height="942" alt="Screenshot 2026-06-15 at 10 16 05 am" src="https://github.com/user-attachments/assets/431cb271-154e-4ed8-b3fd-8eb7ce565604" />


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added or updated documentation where necessary
- [x] I have run linting and unit tests locally
- [x] The code follows the project's style guidelines
