### PR TITLE
fix: incldue fasta in normalized setting items

### DIFF
--- a/src/app/pages/job-details/job-details.spec.ts
+++ b/src/app/pages/job-details/job-details.spec.ts
@@ -22,7 +22,7 @@ type JobDetailsPrivateApi = {
   formatValidationDetails: (
     validation: Record<string, unknown> | undefined
   ) => string[];
-  isPdbSettingKey: (key: string) => boolean;
+  isFileDownloadKey: (key: string) => boolean;
   extractFilename: (path: string) => string;
 };
 
@@ -643,19 +643,26 @@ describe("JobDetailsComponent", () => {
     expect(privateApi().formatValidationDetails(undefined)).toEqual([]);
   });
 
-  describe("isPdbSettingKey", () => {
+  describe("isFileDownloadKey", () => {
     it("should return true for keys containing 'pdb'", () => {
       const api = privateApi();
-      expect(api.isPdbSettingKey("starting_pdb")).toBeTrue();
-      expect(api.isPdbSettingKey("PDB_input")).toBeTrue();
-      expect(api.isPdbSettingKey("my_pdb_file")).toBeTrue();
+      expect(api.isFileDownloadKey("starting_pdb")).toBeTrue();
+      expect(api.isFileDownloadKey("PDB_input")).toBeTrue();
+      expect(api.isFileDownloadKey("my_pdb_file")).toBeTrue();
     });
 
-    it("should return false for keys that do not contain 'pdb'", () => {
+    it("should return true for keys containing 'fasta'", () => {
       const api = privateApi();
-      expect(api.isPdbSettingKey("binder_name")).toBeFalse();
-      expect(api.isPdbSettingKey("min_length")).toBeFalse();
-      expect(api.isPdbSettingKey("chains")).toBeFalse();
+      expect(api.isFileDownloadKey("fastaS3Uri")).toBeTrue();
+      expect(api.isFileDownloadKey("fastaFileUrl")).toBeTrue();
+      expect(api.isFileDownloadKey("FASTA_input")).toBeTrue();
+    });
+
+    it("should return false for keys that do not contain 'pdb' or 'fasta'", () => {
+      const api = privateApi();
+      expect(api.isFileDownloadKey("binder_name")).toBeFalse();
+      expect(api.isFileDownloadKey("min_length")).toBeFalse();
+      expect(api.isFileDownloadKey("chains")).toBeFalse();
     });
   });
 

--- a/src/app/pages/job-details/job-details.ts
+++ b/src/app/pages/job-details/job-details.ts
@@ -496,27 +496,28 @@ export default class JobDetailsComponent implements OnInit {
       }
       details.push(...this.formatValidationDetails(value.validation));
       const rawValue = this.formatSettingValue(value.value);
-      const isPdb = this.isPdbSettingKey(key);
+      const isFileDownload = this.isFileDownloadKey(key);
       return {
         label: value.label || this.formatSettingLabel(key),
-        value: isPdb ? this.extractFilename(rawValue) : rawValue,
+        value: isFileDownload ? this.extractFilename(rawValue) : rawValue,
         details,
-        ...(isPdb && rawValue.startsWith("http") ? { url: rawValue } : {}),
+        ...(isFileDownload && rawValue.startsWith("http") ? { url: rawValue } : {}),
       };
     }
 
     const rawValue = this.formatSettingValue(value);
-    const isPdb = this.isPdbSettingKey(key);
+    const isFileDownload = this.isFileDownloadKey(key);
     return {
       label: this.formatSettingLabel(key),
-      value: isPdb ? this.extractFilename(rawValue) : rawValue,
+      value: isFileDownload ? this.extractFilename(rawValue) : rawValue,
       details: [],
-      ...(isPdb && rawValue.startsWith("http") ? { url: rawValue } : {}),
+      ...(isFileDownload && rawValue.startsWith("http") ? { url: rawValue } : {}),
     };
   }
 
-  private isPdbSettingKey(key: string): boolean {
-    return key.toLowerCase().includes("pdb");
+  private isFileDownloadKey(key: string): boolean {
+    const lower = key.toLowerCase();
+    return lower.includes("pdb") || lower.includes("fasta");
   }
 
   private extractFilename(path: string): string {

--- a/src/app/pages/job-details/job-details.ts
+++ b/src/app/pages/job-details/job-details.ts
@@ -501,7 +501,9 @@ export default class JobDetailsComponent implements OnInit {
         label: value.label || this.formatSettingLabel(key),
         value: isFileDownload ? this.extractFilename(rawValue) : rawValue,
         details,
-        ...(isFileDownload && rawValue.startsWith("http") ? { url: rawValue } : {}),
+        ...(isFileDownload && rawValue.startsWith("http")
+          ? { url: rawValue }
+          : {}),
       };
     }
 
@@ -511,7 +513,9 @@ export default class JobDetailsComponent implements OnInit {
       label: this.formatSettingLabel(key),
       value: isFileDownload ? this.extractFilename(rawValue) : rawValue,
       details: [],
-      ...(isFileDownload && rawValue.startsWith("http") ? { url: rawValue } : {}),
+      ...(isFileDownload && rawValue.startsWith("http")
+        ? { url: rawValue }
+        : {}),
     };
   }
 


### PR DESCRIPTION
In Job Details Page, we're currently just parse download link for pdb file (De Novo Design).

Added `fasta` file to be included (Single Prediction, Interaction Screening). Demo as below

<img width="1470" height="844" alt="Screenshot 2026-06-22 at 11 16 34 am" src="https://github.com/user-attachments/assets/80e412eb-b96c-4f06-93f8-fd87cd333b0d" />


