### PR TITLE
feat: enable download all button on job details page (SBP-388)

### DIFF
--- a/src/app/cores/services/results.service.spec.ts
+++ b/src/app/cores/services/results.service.spec.ts
@@ -45,6 +45,12 @@ describe("ResultsService", () => {
     );
   });
 
+  it("should build the encoded download-all URL", () => {
+    expect(service.getDownloadAllUrl("job/1")).toBe(
+      `${environment.apiBaseUrl}/api/results/job%2F1/download-all`
+    );
+  });
+
   it("should fetch setting params", () => {
     service.getJobSettingParams("job/1").subscribe((response) => {
       expect(response.settingParams).toEqual({ binder_name: "PDL1" });

--- a/src/app/cores/services/results.service.ts
+++ b/src/app/cores/services/results.service.ts
@@ -76,6 +76,10 @@ export class ResultsService {
     );
   }
 
+  getDownloadAllUrl(runId: string): string {
+    return `${this.resultsUrl}/${encodeURIComponent(runId)}/download-all`;
+  }
+
   /**
    * Normalizes report preview URLs into an absolute HTTPS URL that is safe to hand to an iframe.
    *

--- a/src/app/pages/job-details/job-details.html
+++ b/src/app/pages/job-details/job-details.html
@@ -47,18 +47,32 @@
             Delete
           </span>
         </app-button>
+        @if (downloadAllUrl(); as downloadUrl) {
+        <a
+          [href]="downloadUrl"
+          download
+          class="rounded-md px-4 py-2.5 text-sm font-medium transition-all whitespace-nowrap overflow-hidden text-white bg-biocommons-primary hover:bg-sky-900 inline-flex items-center"
+          title="Download all files"
+        >
+          <span class="flex items-center gap-2">
+            <ng-icon name="heroArrowDownTray" size="16"></ng-icon>
+            Download all files
+          </span>
+        </a>
+        } @else {
         <app-button
           type="button"
           variant="primary"
           widthClass="w-auto"
           [disabled]="true"
-          title="Download all files (coming soon)"
+          title="Download all files"
         >
           <span class="flex items-center gap-2">
             <ng-icon name="heroArrowDownTray" size="16"></ng-icon>
             Download all files
           </span>
         </app-button>
+        }
       </div>
       }
     </div>

--- a/src/app/pages/job-details/job-details.spec.ts
+++ b/src/app/pages/job-details/job-details.spec.ts
@@ -83,6 +83,7 @@ describe("JobDetailsComponent", () => {
     resultsService = jasmine.createSpyObj<ResultsService>("ResultsService", [
       "getJobReport",
       "getJobDownloads",
+      "getDownloadAllUrl",
       "getJobSettingParams",
       "getJobLogs",
     ]);
@@ -112,6 +113,9 @@ describe("JobDetailsComponent", () => {
     );
     resultsService.getJobDownloads.and.returnValue(
       of({ runId: mockJob.id, downloads: [] })
+    );
+    resultsService.getDownloadAllUrl.and.returnValue(
+      `${environment.apiBaseUrl}/api/results/${mockJob.id}/download-all`
     );
     resultsService.getJobSettingParams.and.returnValue(
       of({
@@ -215,6 +219,48 @@ describe("JobDetailsComponent", () => {
     expect(mockJobsService.deleteJob).toHaveBeenCalledWith(mockJob.id);
     expect(navigateSpy).toHaveBeenCalledWith(["/jobs"]);
     expect(component.showDeleteDialog()).toBeFalse();
+  });
+
+  it("should render the download all files link for the selected job", () => {
+    resultsService.getJobDownloads.and.returnValue(
+      of({
+        runId: mockJob.id,
+        downloads: [
+          {
+            label: "Results CSV",
+            key: "results_csv",
+            url: "https://cdn.test/results.csv",
+            category: "stat_csv",
+          },
+        ],
+      })
+    );
+    render();
+
+    const downloadLink = fixture.nativeElement.querySelector(
+      'a[title="Download all files"]'
+    ) as HTMLAnchorElement;
+
+    expect(resultsService.getDownloadAllUrl).toHaveBeenCalledWith(mockJob.id);
+    expect(downloadLink.href).toBe(
+      `${environment.apiBaseUrl}/api/results/${mockJob.id}/download-all`
+    );
+    expect(downloadLink.download).toBe("");
+  });
+
+  it("should render a disabled download all files button when no files are available", () => {
+    render();
+
+    const downloadLink = fixture.nativeElement.querySelector(
+      'a[title="Download all files"]'
+    ) as HTMLAnchorElement | null;
+    const downloadButton = fixture.nativeElement.querySelector(
+      'app-button[title="Download all files"] button'
+    ) as HTMLButtonElement;
+
+    expect(downloadLink).toBeNull();
+    expect(downloadButton.disabled).toBeTrue();
+    expect(resultsService.getDownloadAllUrl).not.toHaveBeenCalled();
   });
 
   // --- Results panel --------------------------------------------------------
@@ -497,12 +543,15 @@ describe("JobDetailsComponent", () => {
     component.setActiveTab("settings");
     fixture.detectChanges();
 
-    const anchor = fixture.nativeElement.querySelector(
-      "a[download]"
-    ) as HTMLAnchorElement;
+    const anchors = Array.from(
+      fixture.nativeElement.querySelectorAll("a[download]")
+    ) as HTMLAnchorElement[];
+    const anchor = anchors.find((link) =>
+      link.href.includes("api.example.com/uploads/target.pdb")
+    );
     expect(anchor).not.toBeNull();
-    expect(anchor.textContent?.trim()).toBe("target.pdb");
-    expect(anchor.href).toContain("api.example.com/uploads/target.pdb");
+    expect(anchor?.textContent?.trim()).toBe("target.pdb");
+    expect(anchor?.href).toContain("api.example.com/uploads/target.pdb");
   });
 
   it("should reset logs without loading when there is no selected job", () => {

--- a/src/app/pages/job-details/job-details.ts
+++ b/src/app/pages/job-details/job-details.ts
@@ -102,9 +102,7 @@ export default class JobDetailsComponent implements OnInit {
   logsError = signal<string | null>(null);
   canDownloadAllFiles = computed(
     () =>
-      !this.filesLoading() &&
-      !this.filesError() &&
-      this.filesItems().length > 0
+      !this.filesLoading() && !this.filesError() && this.filesItems().length > 0
   );
   downloadAllUrl = computed(() => {
     const job = this.job();

--- a/src/app/pages/job-details/job-details.ts
+++ b/src/app/pages/job-details/job-details.ts
@@ -1,4 +1,11 @@
-import { Component, effect, inject, OnInit, signal } from "@angular/core";
+import {
+  Component,
+  computed,
+  effect,
+  inject,
+  OnInit,
+  signal,
+} from "@angular/core";
 import { ActivatedRoute, Router, RouterLink } from "@angular/router";
 import { SafeResourceUrl } from "@angular/platform-browser";
 import { DatePipe } from "@angular/common";
@@ -93,6 +100,18 @@ export default class JobDetailsComponent implements OnInit {
   logsItems = signal<string[]>([]);
   logsLoading = signal(false);
   logsError = signal<string | null>(null);
+  canDownloadAllFiles = computed(
+    () =>
+      !this.filesLoading() &&
+      !this.filesError() &&
+      this.filesItems().length > 0
+  );
+  downloadAllUrl = computed(() => {
+    const job = this.job();
+    return job && this.canDownloadAllFiles()
+      ? this.resultsService.getDownloadAllUrl(job.id)
+      : null;
+  });
 
   readonly tabs: Array<{ id: JobResultsTab; label: string; icon: string }> = [
     { id: "results", label: "Results", icon: "heroChartBarSquare" },


### PR DESCRIPTION
# Pull Request

## Summary

[SBP-388](https://biocloud.atlassian.net/browse/SBP-388) enable download all button for job details page, conditional on files being available

## Changes

- Add `getDownloadAllUrl` to results service
- Add link to download all button, enabled if files are available
- Unit tests

## How to Test

`ng test`

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added or updated documentation where necessary
- [x] I have run linting and unit tests locally
- [x] The code follows the project's style guidelines


[SBP-388]: https://biocloud.atlassian.net/browse/SBP-388?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ