### PR TITLE
fix: rework download all button so download request is authenticated (SBP-388)

### DIFF
--- a/src/app/cores/services/results.service.spec.ts
+++ b/src/app/cores/services/results.service.spec.ts
@@ -51,6 +51,24 @@ describe("ResultsService", () => {
     );
   });
 
+  it("should download all files as a blob response", () => {
+    service.downloadAll("job/1").subscribe((response) => {
+      expect(response.body?.type).toBe("application/zip");
+      expect(response.headers.get("content-disposition")).toBe(
+        'attachment; filename="results.zip"'
+      );
+    });
+
+    const request = httpMock.expectOne(
+      `${environment.apiBaseUrl}/api/results/job%2F1/download-all`
+    );
+    expect(request.request.method).toBe("GET");
+    expect(request.request.responseType).toBe("blob");
+    request.flush(new Blob(["zip"], { type: "application/zip" }), {
+      headers: { "content-disposition": 'attachment; filename="results.zip"' },
+    });
+  });
+
   it("should fetch setting params", () => {
     service.getJobSettingParams("job/1").subscribe((response) => {
       expect(response.settingParams).toEqual({ binder_name: "PDL1" });

--- a/src/app/cores/services/results.service.ts
+++ b/src/app/cores/services/results.service.ts
@@ -1,4 +1,4 @@
-import { HttpClient } from "@angular/common/http";
+import { HttpClient, HttpResponse } from "@angular/common/http";
 import { inject, Injectable } from "@angular/core";
 import { DomSanitizer, SafeResourceUrl } from "@angular/platform-browser";
 import normalizeUrlPath from "als-normalize-urlpath";
@@ -78,6 +78,13 @@ export class ResultsService {
 
   getDownloadAllUrl(runId: string): string {
     return `${this.resultsUrl}/${encodeURIComponent(runId)}/download-all`;
+  }
+
+  downloadAll(runId: string): Observable<HttpResponse<Blob>> {
+    return this.http.get(this.getDownloadAllUrl(runId), {
+      observe: "response",
+      responseType: "blob",
+    });
   }
 
   /**

--- a/src/app/pages/job-details/job-details.html
+++ b/src/app/pages/job-details/job-details.html
@@ -47,32 +47,20 @@
             Delete
           </span>
         </app-button>
-        @if (downloadAllUrl(); as downloadUrl) {
-        <a
-          [href]="downloadUrl"
-          download
-          class="rounded-md px-4 py-2.5 text-sm font-medium transition-all whitespace-nowrap overflow-hidden text-white bg-biocommons-primary hover:bg-sky-900 inline-flex items-center"
-          title="Download all files"
-        >
-          <span class="flex items-center gap-2">
-            <ng-icon name="heroArrowDownTray" size="16"></ng-icon>
-            Download all files
-          </span>
-        </a>
-        } @else {
         <app-button
           type="button"
           variant="primary"
           widthClass="w-auto"
-          [disabled]="true"
+          [disabled]="!canDownloadAllFiles()"
+          [loading]="downloadingAllFiles()"
           title="Download all files"
+          (click)="downloadAllFiles()"
         >
           <span class="flex items-center gap-2">
             <ng-icon name="heroArrowDownTray" size="16"></ng-icon>
             Download all files
           </span>
         </app-button>
-        }
       </div>
       }
     </div>

--- a/src/app/pages/job-details/job-details.spec.ts
+++ b/src/app/pages/job-details/job-details.spec.ts
@@ -1,4 +1,5 @@
 import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { HttpHeaders, HttpResponse } from "@angular/common/http";
 import { DomSanitizer } from "@angular/platform-browser";
 import { ActivatedRoute, provideRouter, Router } from "@angular/router";
 import { of, throwError } from "rxjs";
@@ -83,7 +84,7 @@ describe("JobDetailsComponent", () => {
     resultsService = jasmine.createSpyObj<ResultsService>("ResultsService", [
       "getJobReport",
       "getJobDownloads",
-      "getDownloadAllUrl",
+      "downloadAll",
       "getJobSettingParams",
       "getJobLogs",
     ]);
@@ -114,8 +115,15 @@ describe("JobDetailsComponent", () => {
     resultsService.getJobDownloads.and.returnValue(
       of({ runId: mockJob.id, downloads: [] })
     );
-    resultsService.getDownloadAllUrl.and.returnValue(
-      `${environment.apiBaseUrl}/api/results/${mockJob.id}/download-all`
+    resultsService.downloadAll.and.returnValue(
+      of(
+        new HttpResponse({
+          body: new Blob(["zip"], { type: "application/zip" }),
+          headers: new HttpHeaders({
+            "content-disposition": 'attachment; filename="results.zip"',
+          }),
+        })
+      )
     );
     resultsService.getJobSettingParams.and.returnValue(
       of({
@@ -221,7 +229,7 @@ describe("JobDetailsComponent", () => {
     expect(component.showDeleteDialog()).toBeFalse();
   });
 
-  it("should render the download all files link for the selected job", () => {
+  it("should render an enabled download all files button for the selected job", () => {
     resultsService.getJobDownloads.and.returnValue(
       of({
         runId: mockJob.id,
@@ -240,12 +248,42 @@ describe("JobDetailsComponent", () => {
     const downloadLink = fixture.nativeElement.querySelector(
       'a[title="Download all files"]'
     ) as HTMLAnchorElement;
+    const downloadButton = fixture.nativeElement.querySelector(
+      'app-button[title="Download all files"] button'
+    ) as HTMLButtonElement;
 
-    expect(resultsService.getDownloadAllUrl).toHaveBeenCalledWith(mockJob.id);
-    expect(downloadLink.href).toBe(
-      `${environment.apiBaseUrl}/api/results/${mockJob.id}/download-all`
+    expect(downloadLink).toBeNull();
+    expect(downloadButton.disabled).toBeFalse();
+  });
+
+  it("should download all files through the results service", () => {
+    resultsService.getJobDownloads.and.returnValue(
+      of({
+        runId: mockJob.id,
+        downloads: [
+          {
+            label: "Results CSV",
+            key: "results_csv",
+            url: "https://cdn.test/results.csv",
+            category: "stat_csv",
+          },
+        ],
+      })
     );
-    expect(downloadLink.download).toBe("");
+    const createObjectUrlSpy = spyOn(URL, "createObjectURL").and.returnValue(
+      "blob:results"
+    );
+    const revokeObjectUrlSpy = spyOn(URL, "revokeObjectURL");
+    const clickSpy = spyOn(HTMLAnchorElement.prototype, "click");
+    render();
+
+    component.downloadAllFiles();
+
+    expect(resultsService.downloadAll).toHaveBeenCalledWith(mockJob.id);
+    expect(createObjectUrlSpy).toHaveBeenCalledWith(jasmine.any(Blob));
+    expect(clickSpy).toHaveBeenCalled();
+    expect(revokeObjectUrlSpy).toHaveBeenCalledWith("blob:results");
+    expect(component.downloadingAllFiles()).toBeFalse();
   });
 
   it("should render a disabled download all files button when no files are available", () => {
@@ -260,7 +298,6 @@ describe("JobDetailsComponent", () => {
 
     expect(downloadLink).toBeNull();
     expect(downloadButton.disabled).toBeTrue();
-    expect(resultsService.getDownloadAllUrl).not.toHaveBeenCalled();
   });
 
   // --- Results panel --------------------------------------------------------

--- a/src/app/pages/job-details/job-details.ts
+++ b/src/app/pages/job-details/job-details.ts
@@ -10,7 +10,7 @@ import { ActivatedRoute, Router, RouterLink } from "@angular/router";
 import { SafeResourceUrl } from "@angular/platform-browser";
 import { DatePipe } from "@angular/common";
 import { EMPTY } from "rxjs";
-import { catchError } from "rxjs/operators";
+import { catchError, finalize } from "rxjs/operators";
 import { NgIconComponent, provideIcons } from "@ng-icons/core";
 import {
   heroArrowDownTray,
@@ -100,16 +100,11 @@ export default class JobDetailsComponent implements OnInit {
   logsItems = signal<string[]>([]);
   logsLoading = signal(false);
   logsError = signal<string | null>(null);
+  downloadingAllFiles = signal(false);
   canDownloadAllFiles = computed(
     () =>
       !this.filesLoading() && !this.filesError() && this.filesItems().length > 0
   );
-  downloadAllUrl = computed(() => {
-    const job = this.job();
-    return job && this.canDownloadAllFiles()
-      ? this.resultsService.getDownloadAllUrl(job.id)
-      : null;
-  });
 
   readonly tabs: Array<{ id: JobResultsTab; label: string; icon: string }> = [
     { id: "results", label: "Results", icon: "heroChartBarSquare" },
@@ -215,6 +210,35 @@ export default class JobDetailsComponent implements OnInit {
       });
   }
 
+  downloadAllFiles(): void {
+    const job = this.job();
+    if (!job || !this.canDownloadAllFiles() || this.downloadingAllFiles()) {
+      return;
+    }
+
+    this.downloadingAllFiles.set(true);
+    this.resultsService
+      .downloadAll(job.id)
+      .pipe(
+        catchError((err) => {
+          console.error("Error downloading all files:", err);
+          return EMPTY;
+        }),
+        finalize(() => this.downloadingAllFiles.set(false))
+      )
+      .subscribe((response) => {
+        if (!response.body) {
+          return;
+        }
+
+        const filename =
+          this.getDownloadFilename(
+            response.headers.get("content-disposition")
+          ) ?? `${job.id}_results.zip`;
+        this.startBrowserDownload(response.body, filename);
+      });
+  }
+
   setActiveTab(tab: JobResultsTab): void {
     this.activeTab.set(tab);
     if (tab === "logs") {
@@ -310,6 +334,41 @@ export default class JobDetailsComponent implements OnInit {
     this.reportLoading.set(false);
     this.reportUrl.set(null);
     this.reportError.set("Failed to load report.");
+  }
+
+  private getDownloadFilename(
+    contentDisposition: string | null
+  ): string | null {
+    if (!contentDisposition) {
+      return null;
+    }
+
+    const encodedMatch = contentDisposition.match(/filename\*=UTF-8''([^;]+)/i);
+    if (encodedMatch?.[1]) {
+      try {
+        return decodeURIComponent(encodedMatch[1].trim());
+      } catch {
+        return encodedMatch[1].trim();
+      }
+    }
+
+    return (
+      contentDisposition.match(/filename="([^"]+)"/i)?.[1]?.trim() ??
+      contentDisposition.match(/filename=([^;]+)/i)?.[1]?.trim() ??
+      null
+    );
+  }
+
+  private startBrowserDownload(blob: Blob, filename: string): void {
+    const objectUrl = URL.createObjectURL(blob);
+    const link = document.createElement("a");
+    link.href = objectUrl;
+    link.download = filename;
+
+    document.body.appendChild(link);
+    link.click();
+    link.remove();
+    URL.revokeObjectURL(objectUrl);
   }
 
   private loadReport(): void {


### PR DESCRIPTION
<!--
Thank you for contributing! Please fill out the sections below to help maintainers review your change faster.
Delete any sections that don't apply.
-->

# Pull Request

## Summary

[SBP-388](https://biocloud.atlassian.net/browse/SBP-388): didn't think this through properly, the request to the backend needs to be authenticated with an access token, so it can't just be a plain URL. Fixed so it goes through the http client and the Auth0 token is added to the request

## Changes

- Download the results file through httpclient instead of plain URL (access token gets attached)



[SBP-388]: https://biocloud.atlassian.net/browse/SBP-388?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ