### PR TITLE
fix: seamless SSO login when launched from user details page in AAI

### DIFF
--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -37,9 +37,13 @@ export async function getAppConfig(): Promise<ApplicationConfig> {
         domain: environment.auth.domain,
         clientId: environment.auth.clientId,
         cacheLocation: "localstorage",
+        // Use rotating refresh tokens so the session survives without relying on
+        // third-party-cookie iframe checks (which browsers block intermittently).
+        useRefreshTokens: true,
         authorizationParams: {
           audience: environment.auth.audience,
           redirect_uri: window.location.origin,
+          scope: "openid profile email offline_access",
         },
         httpInterceptor: {
           allowedList: [`${apiBaseUrl}/api/*`],

--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -40,6 +40,9 @@ export async function getAppConfig(): Promise<ApplicationConfig> {
         // Use rotating refresh tokens so the session survives without relying on
         // third-party-cookie iframe checks (which browsers block intermittently).
         useRefreshTokens: true,
+        // Fall back to silent iframe auth when no refresh token is cached (e.g.
+        // before login) instead of throwing a "Missing Refresh Token" error.
+        useRefreshTokensFallback: true,
         authorizationParams: {
           audience: environment.auth.audience,
           redirect_uri: window.location.origin,

--- a/src/app/cores/auth.service.spec.ts
+++ b/src/app/cores/auth.service.spec.ts
@@ -716,4 +716,102 @@ describe("AuthService", () => {
       environment.apiBaseUrl = originalApiBaseUrl;
     });
   });
+
+  describe("Auto-login on launch (?login=true)", () => {
+    const originalUrl =
+      window.location.pathname +
+      window.location.search +
+      window.location.hash;
+
+    let localIsAuth: BehaviorSubject<boolean>;
+    let localIsLoading: BehaviorSubject<boolean>;
+    let localMock: jasmine.SpyObj<Auth0Service>;
+    let localRouter: jasmine.SpyObj<Router>;
+    let localHttp: HttpTestingController;
+
+    // Build a fully isolated AuthService instance reading a controlled URL, so
+    // the constructor's handleAutoLogin() runs against `search`. Isolated
+    // subjects keep it from interfering with the suite's shared service.
+    function build(search: string, authenticated: boolean): void {
+      window.history.replaceState({}, "", "/" + search);
+      localIsAuth = new BehaviorSubject<boolean>(authenticated);
+      localIsLoading = new BehaviorSubject<boolean>(true);
+      localRouter = jasmine.createSpyObj("Router", ["navigateByUrl"]);
+      localMock = jasmine.createSpyObj(
+        "AuthService",
+        ["loginWithRedirect", "logout", "getAccessTokenSilently"],
+        {
+          isAuthenticated$: localIsAuth.asObservable(),
+          user$: of(null),
+          error$: of(null),
+          isLoading$: localIsLoading.asObservable(),
+          appState$: of(null),
+        }
+      );
+
+      TestBed.resetTestingModule();
+      TestBed.configureTestingModule({
+        providers: [
+          provideHttpClient(),
+          provideHttpClientTesting(),
+          AuthService,
+          { provide: Auth0Service, useValue: localMock },
+          { provide: Router, useValue: localRouter },
+        ],
+      });
+      TestBed.inject(AuthService);
+      localHttp = TestBed.inject(HttpTestingController);
+    }
+
+    afterEach(() => {
+      window.history.replaceState({}, "", originalUrl);
+      // Flush the user-sync request the authenticated path triggers, if any.
+      localHttp.match(() => true).forEach((req) => req.flush({}));
+      localHttp.verify();
+    });
+
+    it("redirects to Auth0 login when launched unauthenticated", () => {
+      build("?login=true", false);
+      localIsLoading.next(false);
+      expect(localMock.loginWithRedirect).toHaveBeenCalledWith(
+        jasmine.objectContaining({ appState: { target: "/" } })
+      );
+      expect(localRouter.navigateByUrl).not.toHaveBeenCalled();
+    });
+
+    it("navigates without re-login when already authenticated", () => {
+      build("?login=true", true);
+      localIsLoading.next(false);
+      expect(localRouter.navigateByUrl).toHaveBeenCalledWith("/");
+      expect(localMock.loginWithRedirect).not.toHaveBeenCalled();
+    });
+
+    it("does nothing during the Auth0 code callback", () => {
+      build("?login=true&code=abc&state=xyz", false);
+      localIsLoading.next(false);
+      expect(localMock.loginWithRedirect).not.toHaveBeenCalled();
+      expect(localRouter.navigateByUrl).not.toHaveBeenCalled();
+    });
+
+    it("does nothing during an Auth0 state callback", () => {
+      build("?login=true&state=xyz", false);
+      localIsLoading.next(false);
+      expect(localMock.loginWithRedirect).not.toHaveBeenCalled();
+      expect(localRouter.navigateByUrl).not.toHaveBeenCalled();
+    });
+
+    it("does nothing during an Auth0 error callback", () => {
+      build("?login=true&error=access_denied", false);
+      localIsLoading.next(false);
+      expect(localMock.loginWithRedirect).not.toHaveBeenCalled();
+      expect(localRouter.navigateByUrl).not.toHaveBeenCalled();
+    });
+
+    it("ignores launches without the login flag", () => {
+      build("", false);
+      localIsLoading.next(false);
+      expect(localMock.loginWithRedirect).not.toHaveBeenCalled();
+      expect(localRouter.navigateByUrl).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/src/app/cores/auth.service.spec.ts
+++ b/src/app/cores/auth.service.spec.ts
@@ -719,9 +719,7 @@ describe("AuthService", () => {
 
   describe("Auto-login on launch (?login=true)", () => {
     const originalUrl =
-      window.location.pathname +
-      window.location.search +
-      window.location.hash;
+      window.location.pathname + window.location.search + window.location.hash;
 
     let localIsAuth: BehaviorSubject<boolean>;
     let localIsLoading: BehaviorSubject<boolean>;

--- a/src/app/cores/auth.service.ts
+++ b/src/app/cores/auth.service.ts
@@ -6,6 +6,7 @@ import {
   BehaviorSubject,
   Observable,
   catchError,
+  filter,
   map,
   of,
   switchMap,
@@ -24,6 +25,8 @@ interface AuthError {
 })
 export class AuthService {
   private static readonly RETURN_URL_KEY = "sbp.returnUrl";
+  // Query flag set by the AAI portal "Launch" button to request seamless SSO.
+  private static readonly AUTO_LOGIN_PARAM = "login";
   private auth0 = inject(Auth0Service);
   private http = inject(HttpClient);
   private router = inject(Router);
@@ -94,6 +97,51 @@ export class AuthService {
     this.initializeLoadingStates();
     this.initializeBannerHandling();
     this.handleAuthCallback();
+    this.handleAutoLogin();
+  }
+
+  /**
+   * Seamless SSO entry point. When the app is opened with `?login=true` (set by
+   * the AAI portal "Launch" button), trigger a full-page Auth0 redirect. Because
+   * a top-level redirect reads the Auth0 session as a first-party cookie, an
+   * existing SSO session completes without prompting for credentials — unlike
+   * iframe silent auth, which depends on third-party cookies. Organic visitors
+   * (no flag) are left anonymous so the public home page still works.
+   */
+  private handleAutoLogin(): void {
+    const params = new URLSearchParams(window.location.search);
+    if (params.get(AuthService.AUTO_LOGIN_PARAM) !== "true") {
+      return;
+    }
+
+    // Never interfere with the Auth0 redirect callback round-trip.
+    const search = window.location.search;
+    if (
+      search.includes("code=") ||
+      search.includes("state=") ||
+      search.includes("error=")
+    ) {
+      return;
+    }
+
+    // Wait until Auth0 has restored any existing local session before deciding.
+    this.auth0.isLoading$
+      .pipe(
+        filter((loading) => !loading),
+        take(1),
+        switchMap(() => this.auth0.isAuthenticated$.pipe(take(1)))
+      )
+      .subscribe((isAuthenticated) => {
+        // Drop the login flag from the URL so it isn't reused as the return
+        // target after the round-trip.
+        const target =
+          window.location.pathname + window.location.hash || "/binder-design";
+        if (isAuthenticated) {
+          this.router.navigateByUrl(target);
+        } else {
+          this.login(target);
+        }
+      });
   }
 
   private initializeLoadingStates(): void {


### PR DESCRIPTION
<!--
Thank you for contributing! Please fill out the sections below to help maintainers review your change faster.
Delete any sections that don't apply.
-->

# Pull Request

## Summary

[AAI-825](https://biocloud.atlassian.net/browse/AAI-825): Fixes SBP requiring a manual "Login" click (and sometimes re-entering credentials) when launched from the AAI portal, despite an active Auth0 SSO session.

## Changes

- Auto-login when SBP is opened with `?login=true` (set by the portal "Launch" button): triggers a full-page `loginWithRedirect`, which reuses the existing Auth0 SSO session as a first-party cookie → no credential prompt
- Waits for Auth0 to restore any local session first: if already authenticated, just navigates to the landing route instead of redirecting
- Skips auto-login during the Auth0 callback round-trip (code/state/error params)
- Organic visitors (no flag) stay anonymous — the public home page is unaffected
- Enables `useRefreshTokens` + offline_access scope so the session no longer depends on third-party-cookie iframe checks (the cause of the intermittent re-prompt)


Related pull request in aai: https://github.com/AustralianBioCommons/aai-portal/pull/249

## How to Test

CI tests shall pass, when test end to end when both related PRs are in.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added or updated documentation where necessary
- [x] I have run linting and unit tests locally
- [x] The code follows the project's style guidelines


[AAI-825]: https://biocloud.atlassian.net/browse/AAI-825?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ