### PR TITLE
feat: use health service for user job pages

### DIFF
--- a/src/app/cores/services/health.service.spec.ts
+++ b/src/app/cores/services/health.service.spec.ts
@@ -1,0 +1,63 @@
+import { TestBed } from "@angular/core/testing";
+import { provideHttpClient } from "@angular/common/http";
+import {
+  HttpTestingController,
+  provideHttpClientTesting,
+} from "@angular/common/http/testing";
+import { ComponentsHealthResponse, HealthService } from "./health.service";
+import { environment } from "../../../environments/environment";
+
+describe("HealthService", () => {
+  let httpMock: HttpTestingController;
+
+  function setup(): HealthService {
+    TestBed.configureTestingModule({
+      providers: [provideHttpClient(), provideHttpClientTesting()],
+    });
+    httpMock = TestBed.inject(HttpTestingController);
+    return TestBed.inject(HealthService);
+  }
+
+  afterEach(() => {
+    httpMock.verify();
+  });
+
+  it("should be created", () => {
+    expect(setup()).toBeTruthy();
+  });
+
+  it("getComponentsHealth GETs the health endpoint and returns the body", () => {
+    const service = setup();
+    let result: ComponentsHealthResponse | undefined;
+    service.getComponentsHealth().subscribe((r) => (result = r));
+
+    const req = httpMock.expectOne(
+      `${environment.apiBaseUrl}/api/health/components`
+    );
+    expect(req.request.method).toBe("GET");
+
+    const body: ComponentsHealthResponse = {
+      overallStatus: "degraded",
+      checkedAt: "2026-06-25T03:12:55Z",
+      message: "Some workflow services are currently unavailable.",
+    };
+    req.flush(body);
+
+    expect(result).toEqual(body);
+  });
+
+  it("propagates request errors to the caller", () => {
+    const service = setup();
+    let errored = false;
+    service.getComponentsHealth().subscribe({
+      next: () => {},
+      error: () => (errored = true),
+    });
+
+    httpMock
+      .expectOne(`${environment.apiBaseUrl}/api/health/components`)
+      .error(new ProgressEvent("error"));
+
+    expect(errored).toBeTrue();
+  });
+});

--- a/src/app/cores/services/health.service.ts
+++ b/src/app/cores/services/health.service.ts
@@ -1,0 +1,39 @@
+import { HttpClient } from "@angular/common/http";
+import { inject, Injectable } from "@angular/core";
+import { Observable } from "rxjs";
+import { environment } from "../../../environments/environment";
+
+export type HealthStatus = "healthy" | "degraded" | "unhealthy";
+
+/**
+ * Coarse, user-facing health summary returned by GET /api/health/components.
+ *
+ * The backend deliberately collapses all monitored components into a single
+ * signal: it does not surface *which* component is affected, only whether some
+ * dependency is degraded, plus a generic user-facing message (null when healthy).
+ */
+export interface ComponentsHealthResponse {
+  overallStatus: HealthStatus;
+  checkedAt: string;
+  message: string | null;
+}
+
+/**
+ * Service for the user-facing system health summary used to warn that job
+ * status / logs may be stale while a component is offline.
+ */
+@Injectable({
+  providedIn: "root",
+})
+export class HealthService {
+  private readonly healthUrl = `${environment.apiBaseUrl}/api/health/components`;
+  private http = inject(HttpClient);
+
+  /**
+   * Fetch the coarse system health summary.
+   * @returns Observable of ComponentsHealthResponse
+   */
+  getComponentsHealth(): Observable<ComponentsHealthResponse> {
+    return this.http.get<ComponentsHealthResponse>(this.healthUrl);
+  }
+}

--- a/src/app/cores/services/jobs.service.spec.ts
+++ b/src/app/cores/services/jobs.service.spec.ts
@@ -70,9 +70,7 @@ describe("JobsService", () => {
   });
 
   it("should resolve a job by run id from the listing and normalize it", () => {
-    let result:
-      | { job: JobListItem | null; seqeraUnavailable: boolean }
-      | undefined;
+    let result: JobListItem | null | undefined;
     service.getJob("run-2").subscribe((r) => (result = r));
 
     const req = httpMock.expectOne(
@@ -107,20 +105,17 @@ describe("JobsService", () => {
       offset: 0,
     });
 
-    expect(result?.job).toEqual(
+    expect(result).toEqual(
       jasmine.objectContaining({
         id: "run-2",
         workflow: "wf-b",
         finalDesignCount: 5,
       })
     );
-    expect(result?.seqeraUnavailable).toBeFalse();
   });
 
   it("should return null from getJob when no job matches the run id", () => {
-    let result:
-      | { job: JobListItem | null; seqeraUnavailable: boolean }
-      | undefined;
+    let result: JobListItem | null | undefined;
     service.getJob("missing").subscribe((r) => (result = r));
 
     const req = httpMock.expectOne(
@@ -128,7 +123,7 @@ describe("JobsService", () => {
     );
     req.flush({ jobs: [], total: 0, limit: 1000, offset: 0 });
 
-    expect(result?.job).toBeNull();
+    expect(result).toBeNull();
   });
 
   it("should fall back to defaults when normalizing a job without aliases", () => {

--- a/src/app/cores/services/jobs.service.ts
+++ b/src/app/cores/services/jobs.service.ts
@@ -25,7 +25,6 @@ export interface JobListResponse {
   total: number;
   limit: number;
   offset: number;
-  seqeraUnavailable?: boolean;
 }
 
 /**
@@ -103,16 +102,11 @@ export class JobsService {
    * @param runId The job run id
    * @returns Observable of the matching JobListItem, or null if not found
    */
-  getJob(
-    runId: string
-  ): Observable<{ job: JobListItem | null; seqeraUnavailable: boolean }> {
+  getJob(runId: string): Observable<JobListItem | null> {
     return this.listJobs({ limit: 1000, offset: 0 }).pipe(
       map((response) => {
         const job = response.jobs.find((item) => item.id === runId);
-        return {
-          job: job ? this.normalizeJob(job) : null,
-          seqeraUnavailable: response.seqeraUnavailable ?? false,
-        };
+        return job ? this.normalizeJob(job) : null;
       })
     );
   }

--- a/src/app/pages/job-details/job-details.html
+++ b/src/app/pages/job-details/job-details.html
@@ -1,9 +1,9 @@
-<!-- Seqera Unavailable Warning -->
-@if (seqeraUnavailable()) {
+<!-- System Health Warning -->
+@if (systemUnhealthy()) {
 <app-alert
   type="warning"
   position="fixed"
-  message="Seqera services are currently unavailable. Job status and logs may not be up to date."
+  [message]="healthMessage() ?? 'Some workflow services are currently unavailable. Job status and logs may not be up to date until the service is restored.'"
 ></app-alert>
 }
 

--- a/src/app/pages/job-details/job-details.spec.ts
+++ b/src/app/pages/job-details/job-details.spec.ts
@@ -10,6 +10,7 @@ import {
   ResultsService,
 } from "../../cores/services/results.service";
 import { JobListItem, JobsService } from "../../cores/services/jobs.service";
+import { HealthService } from "../../cores/services/health.service";
 import { environment } from "../../../environments/environment";
 
 type JobDetailsPrivateApi = {
@@ -32,6 +33,7 @@ describe("JobDetailsComponent", () => {
   let fixture: ComponentFixture<JobDetailsComponent>;
   let mockJobsService: jasmine.SpyObj<JobsService>;
   let resultsService: jasmine.SpyObj<ResultsService>;
+  let mockHealthService: jasmine.SpyObj<HealthService>;
   let sanitizer: DomSanitizer;
   let routeId: string | null;
 
@@ -69,9 +71,7 @@ describe("JobDetailsComponent", () => {
       "listJobs",
     ]);
     mockJobsService.normalizeJob.and.callFake((job) => job);
-    mockJobsService.getJob.and.returnValue(
-      of({ job: mockJob, seqeraUnavailable: false })
-    );
+    mockJobsService.getJob.and.returnValue(of(mockJob));
     mockJobsService.deleteJob.and.returnValue(
       of({
         runId: mockJob.id,
@@ -89,12 +89,24 @@ describe("JobDetailsComponent", () => {
       "getJobLogs",
     ]);
 
+    mockHealthService = jasmine.createSpyObj("HealthService", [
+      "getComponentsHealth",
+    ]);
+    mockHealthService.getComponentsHealth.and.returnValue(
+      of({
+        overallStatus: "healthy",
+        checkedAt: "2026-06-25T03:12:55Z",
+        message: null,
+      })
+    );
+
     await TestBed.configureTestingModule({
       imports: [JobDetailsComponent],
       providers: [
         provideRouter([]),
         { provide: JobsService, useValue: mockJobsService },
         { provide: ResultsService, useValue: resultsService },
+        { provide: HealthService, useValue: mockHealthService },
         {
           provide: ActivatedRoute,
           useValue: {
@@ -197,9 +209,7 @@ describe("JobDetailsComponent", () => {
   });
 
   it("should show an error when the job cannot be found", () => {
-    mockJobsService.getJob.and.returnValue(
-      of({ job: null, seqeraUnavailable: false })
-    );
+    mockJobsService.getJob.and.returnValue(of(null));
     render();
 
     expect(component.error()).toBe("Job not found.");

--- a/src/app/pages/job-details/job-details.ts
+++ b/src/app/pages/job-details/job-details.ts
@@ -28,6 +28,7 @@ import { LoadingComponent } from "../../components/loading/loading.component";
 import { DialogComponent } from "../../components/dialog/dialog.component";
 import { ButtonComponent } from "../../components/button/button.component";
 import { JobListItem, JobsService } from "../../cores/services/jobs.service";
+import { HealthService } from "../../cores/services/health.service";
 import {
   ResultLogsResponse,
   ResultsService,
@@ -74,13 +75,18 @@ export default class JobDetailsComponent implements OnInit {
   private router = inject(Router);
   private jobsService = inject(JobsService);
   private resultsService = inject(ResultsService);
+  private healthService = inject(HealthService);
   private datePipe = inject(DatePipe);
 
   // Page state
   job = signal<JobListItem | null>(null);
   loading = signal<boolean>(false);
   error = signal<string | null>(null);
-  seqeraUnavailable = signal<boolean>(false);
+  // Driven by the system health API (GET /api/health/components): true when any
+  // monitored component is not healthy, so we can warn that job status / logs may
+  // be stale. The accompanying message comes from the backend.
+  systemUnhealthy = signal<boolean>(false);
+  healthMessage = signal<string | null>(null);
   showDeleteDialog = signal<boolean>(false);
   deleting = signal<boolean>(false);
 
@@ -121,9 +127,6 @@ export default class JobDetailsComponent implements OnInit {
     const navigatedJob = navState?.["job"] as JobListItem | undefined;
     if (navigatedJob) {
       this.job.set(this.jobsService.normalizeJob(navigatedJob));
-      this.seqeraUnavailable.set(
-        (navState?.["seqeraUnavailable"] as boolean) ?? false
-      );
     }
 
     // Reset and reload the results whenever the selected job changes.
@@ -138,6 +141,8 @@ export default class JobDetailsComponent implements OnInit {
   }
 
   ngOnInit(): void {
+    this.checkSystemHealth();
+
     const id = this.route.snapshot.paramMap.get("id");
     if (!id) {
       this.error.set("Job not found.");
@@ -150,6 +155,27 @@ export default class JobDetailsComponent implements OnInit {
     }
 
     this.loadJob(id);
+  }
+
+  /**
+   * Check overall system health and surface a warning when any monitored
+   * component is not healthy. Best-effort: a failed health check leaves the
+   * page untouched.
+   */
+  private checkSystemHealth(): void {
+    this.healthService
+      .getComponentsHealth()
+      .pipe(
+        catchError((err) => {
+          console.error("Error checking system health:", err);
+          return EMPTY;
+        })
+      )
+      .subscribe((health) => {
+        const unhealthy = health.overallStatus !== "healthy";
+        this.systemUnhealthy.set(unhealthy);
+        this.healthMessage.set(unhealthy ? health.message : null);
+      });
   }
 
   private loadJob(id: string): void {
@@ -165,13 +191,12 @@ export default class JobDetailsComponent implements OnInit {
           return EMPTY;
         })
       )
-      .subscribe(({ job, seqeraUnavailable }) => {
+      .subscribe((job) => {
         if (!job) {
           this.error.set("Job not found.");
         } else {
           this.job.set(job);
         }
-        this.seqeraUnavailable.set(seqeraUnavailable);
         this.loading.set(false);
       });
   }

--- a/src/app/pages/jobs/jobs.html
+++ b/src/app/pages/jobs/jobs.html
@@ -116,12 +116,12 @@
     </div>
     }
 
-    <!-- Seqera Unavailable Warning -->
-    @if (seqeraUnavailable()) {
+    <!-- System Health Warning -->
+    @if (systemUnhealthy()) {
     <app-alert
       type="warning"
       position="fixed"
-      message="Seqera services are currently unavailable. Job statuses may not be up to date and logs cannot be retrieved until the service is restored."
+      [message]="healthMessage() ?? 'Some workflow services are currently unavailable. Job status and logs may not be up to date until the service is restored.'"
     ></app-alert>
     } @if (loading()) {
     <!-- Loading State -->

--- a/src/app/pages/jobs/jobs.spec.ts
+++ b/src/app/pages/jobs/jobs.spec.ts
@@ -9,12 +9,23 @@ import {
   JobListResponse,
   JobsService,
 } from "../../cores/services/jobs.service";
+import {
+  ComponentsHealthResponse,
+  HealthService,
+} from "../../cores/services/health.service";
 
 describe("JobsComponent", () => {
   let component: JobsComponent;
   let fixture: ComponentFixture<JobsComponent>;
   let mockJobsService: jasmine.SpyObj<JobsService>;
   let mockResultsService: jasmine.SpyObj<ResultsService>;
+  let mockHealthService: jasmine.SpyObj<HealthService>;
+
+  const healthyResponse: ComponentsHealthResponse = {
+    overallStatus: "healthy",
+    checkedAt: "2026-06-25T03:12:55Z",
+    message: null,
+  };
   let sanitizer: DomSanitizer;
 
   const mockJob: JobListItem = {
@@ -64,6 +75,10 @@ describe("JobsComponent", () => {
       "getJobSettingParams",
       "getJobLogs",
     ]);
+    mockHealthService = jasmine.createSpyObj("HealthService", [
+      "getComponentsHealth",
+    ]);
+    mockHealthService.getComponentsHealth.and.returnValue(of(healthyResponse));
     mockJobsService.listJobs.and.returnValue(of(mockResponse));
     mockJobsService.cancelJob.and.returnValue(
       of({ message: "Cancelled", runId: mockJob.id, status: "Stopped" })
@@ -76,6 +91,7 @@ describe("JobsComponent", () => {
       providers: [
         { provide: JobsService, useValue: mockJobsService },
         { provide: ResultsService, useValue: mockResultsService },
+        { provide: HealthService, useValue: mockHealthService },
         provideRouter([]),
       ],
     }).compileComponents();
@@ -105,6 +121,44 @@ describe("JobsComponent", () => {
 
   it("should create", () => {
     expect(component).toBeTruthy();
+  });
+
+  it("does not flag a warning when all components are healthy", () => {
+    expect(mockHealthService.getComponentsHealth).toHaveBeenCalled();
+    expect(component.systemUnhealthy()).toBeFalse();
+    expect(component.healthMessage()).toBeNull();
+  });
+
+  it("flags a warning with the backend message when a component is not healthy", async () => {
+    mockHealthService.getComponentsHealth.and.returnValue(
+      of({
+        overallStatus: "degraded",
+        checkedAt: "2026-06-25T03:12:55Z",
+        message: "Some workflow services are currently unavailable.",
+      })
+    );
+
+    fixture = TestBed.createComponent(JobsComponent);
+    component = fixture.componentInstance;
+    await detectComponentChanges();
+
+    expect(component.systemUnhealthy()).toBeTrue();
+    expect(component.healthMessage()).toBe(
+      "Some workflow services are currently unavailable."
+    );
+  });
+
+  it("does not surface a warning when the health check fails", async () => {
+    mockHealthService.getComponentsHealth.and.returnValue(
+      throwError(() => new Error("network error"))
+    );
+
+    fixture = TestBed.createComponent(JobsComponent);
+    component = fixture.componentInstance;
+    await detectComponentChanges();
+
+    expect(component.systemUnhealthy()).toBeFalse();
+    expect(component.healthMessage()).toBeNull();
   });
 
   it("should load jobs on init", () => {
@@ -360,7 +414,7 @@ describe("JobsComponent", () => {
     component.viewJobDetails(mockJob);
 
     expect(navigateSpy).toHaveBeenCalledWith(["/jobs", mockJob.id], {
-      state: { job: mockJob, seqeraUnavailable: false },
+      state: { job: mockJob },
     });
   });
 

--- a/src/app/pages/jobs/jobs.ts
+++ b/src/app/pages/jobs/jobs.ts
@@ -10,6 +10,7 @@ import {
   JobListQueryParams,
   JobsService,
 } from "../../cores/services/jobs.service";
+import { HealthService } from "../../cores/services/health.service";
 import { DatePipe } from "@angular/common";
 import { EMPTY } from "rxjs";
 import { catchError } from "rxjs/operators";
@@ -55,6 +56,7 @@ import {
 })
 export default class JobsComponent implements OnInit {
   private jobsService = inject(JobsService);
+  private healthService = inject(HealthService);
   private router = inject(Router);
 
   // Expose Math to template
@@ -65,7 +67,11 @@ export default class JobsComponent implements OnInit {
   total = signal<number>(0);
   loading = signal<boolean>(false);
   error = signal<string | null>(null);
-  seqeraUnavailable = signal<boolean>(false);
+  // Driven by the system health API (GET /api/health/components): true when any
+  // monitored component is not healthy, so we can warn that job status / logs may
+  // be stale. The accompanying message comes from the backend.
+  systemUnhealthy = signal<boolean>(false);
+  healthMessage = signal<string | null>(null);
   selectedJobs = signal<string[]>([]);
   showDeleteDialog = signal(false);
   showStatusDropdown = signal(false);
@@ -84,6 +90,28 @@ export default class JobsComponent implements OnInit {
 
   ngOnInit(): void {
     this.loadJobs();
+    this.checkSystemHealth();
+  }
+
+  /**
+   * Check overall system health and surface a warning when any monitored
+   * component is not healthy. Best-effort: a failed health check leaves the
+   * jobs UI untouched.
+   */
+  private checkSystemHealth(): void {
+    this.healthService
+      .getComponentsHealth()
+      .pipe(
+        catchError((err) => {
+          console.error("Error checking system health:", err);
+          return EMPTY;
+        })
+      )
+      .subscribe((health) => {
+        const unhealthy = health.overallStatus !== "healthy";
+        this.systemUnhealthy.set(unhealthy);
+        this.healthMessage.set(unhealthy ? health.message : null);
+      });
   }
 
   /**
@@ -92,7 +120,6 @@ export default class JobsComponent implements OnInit {
   loadJobs(): void {
     this.loading.set(true);
     this.error.set(null);
-    this.seqeraUnavailable.set(false);
     this.selectedJobs.set([]); // Clear selection when reloading
 
     const params: JobListQueryParams = {
@@ -133,7 +160,6 @@ export default class JobsComponent implements OnInit {
         });
         this.jobs.set(this.sortJobs(normalizedJobs));
         this.total.set(response.total);
-        this.seqeraUnavailable.set(response.seqeraUnavailable ?? false);
         this.loading.set(false);
       });
   }
@@ -408,7 +434,7 @@ export default class JobsComponent implements OnInit {
 
   viewJobDetails(job: JobListItem): void {
     this.router.navigate(["/jobs", job.id], {
-      state: { job, seqeraUnavailable: this.seqeraUnavailable() },
+      state: { job },
     });
   }
 }


### PR DESCRIPTION
<!--
Thank you for contributing! Please fill out the sections below to help maintainers review your change faster.
Delete any sections that don't apply.
-->

# Pull Request

## Summary

[SBP-408](https://biocloud.atlassian.net/browse/SBP-408): drive the jobs/job-details health warning from `/api/health/components`

## Changes

- Adds `HealthService` — `getComponentsHealth()` calls `GET /api/health/components`, typed as `ComponentsHealthResponse { overallStatus, checkedAt, message }`.
- Jobs dashboard shows the warning when `overallStatus !== "healthy"`, rendering the backend-provided message (with a static fallback).
- Job-details page - same warning, now health-API-driven instead of via router navigation state.
- Removes the old `seqeraUnavailable` plumbing: dropped from `JobListResponse`, `JobsService.getJob()` now returns `JobListItem | null`, and the navigation-state key is gone.
- Renames the page signal `seqeraUnavailable` → `systemUnhealth`y to match the health-check semantics

## How to Test

<img width="1512" height="910" alt="Screenshot 2026-06-26 at 11 24 23 am" src="https://github.com/user-attachments/assets/f3615455-1ced-4b50-9246-30810f858c73" />
<img width="1512" height="910" alt="Screenshot 2026-06-26 at 11 24 10 am" src="https://github.com/user-attachments/assets/0f5ff0b4-2198-48c1-89cb-425aafee949d" />


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have added or updated documentation where necessary
- [X] I have run linting and unit tests locally
- [X] The code follows the project's style guidelines


[SBP-408]: https://biocloud.atlassian.net/browse/SBP-408?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ