### PR TITLE
feat: single prediction sequence name for fasta

### DIFF
--- a/src/app/features/workflows/shared/fasta.utils.spec.ts
+++ b/src/app/features/workflows/shared/fasta.utils.spec.ts
@@ -4,6 +4,7 @@ import {
   isValidSmiles,
   parseMultiFasta,
   validateDnaSequence,
+  validateFastaHeader,
   validateMultiFastaProtein,
   validateProteinSequence,
   validateRnaSequence,
@@ -11,6 +12,44 @@ import {
 } from "./fasta.utils";
 
 describe("fasta.utils", () => {
+  describe("validateFastaHeader", () => {
+    it("accepts a simple name", () => {
+      expect(validateFastaHeader("seq1")).toEqual({ valid: true });
+    });
+
+    it("rejects an empty name", () => {
+      expect(validateFastaHeader("   ")).toEqual({
+        valid: false,
+        errorMessage: "Sequence name is required.",
+      });
+    });
+
+    it("rejects names containing spaces", () => {
+      expect(validateFastaHeader("seq 1")).toEqual({
+        valid: false,
+        errorMessage: "Sequence name must not contain spaces.",
+      });
+    });
+
+    it("rejects names containing underscores", () => {
+      expect(validateFastaHeader("seq_1")).toEqual({
+        valid: false,
+        errorMessage: "Sequence name must not contain underscores.",
+      });
+    });
+
+    it("rejects a name that duplicates an existing name", () => {
+      expect(validateFastaHeader("seq1", ["seq1", "seq2"])).toEqual({
+        valid: false,
+        errorMessage: "Sequence name must be unique.",
+      });
+    });
+
+    it("trims surrounding whitespace before validating", () => {
+      expect(validateFastaHeader("  seq1  ")).toEqual({ valid: true });
+    });
+  });
+
   describe("validateProteinSequence", () => {
     it("accepts valid protein characters", () => {
       expect(validateProteinSequence("MKT AYI").valid).toBe(true);

--- a/src/app/features/workflows/shared/fasta.utils.ts
+++ b/src/app/features/workflows/shared/fasta.utils.ts
@@ -9,6 +9,32 @@ export interface MultiFastaValidationResult {
   sequenceCount: number;
 }
 
+/**
+ * Validates a single FASTA sequence name — the identifier text that follows
+ * the ">" character on a header line.  The same rules applied when parsing
+ * multi-FASTA blocks (non-empty, no surrounding whitespace, no embedded
+ * spaces that would split the ID from a description field).
+ */
+export function validateFastaHeader(
+  name: string,
+  existingNames?: string[]
+): SequenceValidationResult {
+  const trimmed = name.trim();
+  if (!trimmed) {
+    return { valid: false, errorMessage: "Sequence name is required." };
+  }
+  if (/\s/.test(trimmed)) {
+    return {
+      valid: false,
+      errorMessage: "Sequence name must not contain spaces.",
+    };
+  }
+  if (existingNames?.some((n) => n.trim() === trimmed)) {
+    return { valid: false, errorMessage: "Sequence name must be unique." };
+  }
+  return { valid: true };
+}
+
 export interface CcdLookupResult {
   valid: boolean;
   name?: string;

--- a/src/app/features/workflows/shared/fasta.utils.ts
+++ b/src/app/features/workflows/shared/fasta.utils.ts
@@ -29,6 +29,12 @@ export function validateFastaHeader(
       errorMessage: "Sequence name must not contain spaces.",
     };
   }
+  if (trimmed.includes("_")) {
+    return {
+      valid: false,
+      errorMessage: "Sequence name must not contain underscores.",
+    };
+  }
   if (existingNames?.some((n) => n.trim() === trimmed)) {
     return { valid: false, errorMessage: "Sequence name must be unique." };
   }

--- a/src/app/features/workflows/single-prediction/single-prediction.html
+++ b/src/app/features/workflows/single-prediction/single-prediction.html
@@ -223,13 +223,7 @@
                   (valueChange)="updateRowSequence(row.id, $event)"
                   (blurred)="touchRowField(row.id, 'sequence')"
                 ></app-listbox-select>
-
-                @if (shouldShowRowFieldError(row, 'sequence') &&
-                getRowErrors(i).sequence) {
-                <p class="mt-1 text-xs text-red-600" role="alert">
-                  {{ getRowErrors(i).sequence }}
-                </p>
-                } } @else {
+                } @else {
                 <div
                   class="overflow-hidden rounded-md border transition-colors focus-within:ring-2"
                   [class]="
@@ -283,14 +277,12 @@
                     ></textarea>
                   </div>
                 </div>
-
-                <!-- Sequence error -->
-                @if (shouldShowRowFieldError(row, 'sequence') &&
+                } @if (shouldShowRowFieldError(row, 'sequence') &&
                 getRowErrors(i).sequence) {
                 <p class="mt-1 text-xs text-red-600" role="alert">
                   {{ getRowErrors(i).sequence }}
                 </p>
-                } } @if (shouldShowRowToolError(row) && getRowErrors(i).tool) {
+                } @if (shouldShowRowToolError(row) && getRowErrors(i).tool) {
                 <p class="mt-1 text-xs text-red-600" role="alert">
                   {{ getRowErrors(i).tool }}
                 </p>

--- a/src/app/features/workflows/single-prediction/single-prediction.html
+++ b/src/app/features/workflows/single-prediction/single-prediction.html
@@ -208,11 +208,13 @@
                   </div>
 
                   <div
-                    class="overflow-hidden rounded-md border transition-colors focus-within:ring-2"
+                    class="rounded-md border transition-colors focus-within:ring-2"
                     [class]="
-                      shouldShowRowFieldError(row, 'name') && getRowErrors(i).name
+                      (row.moleculeType === 'ccd' ? 'overflow-visible' : 'overflow-hidden') +
+                      ' ' +
+                      (shouldShowRowFieldError(row, 'name') && getRowErrors(i).name
                         ? 'border-red-300 focus-within:ring-red-100'
-                        : 'border-gray-200 focus-within:ring-sky-100'
+                        : 'border-gray-200 focus-within:ring-sky-100')
                     "
                   >
                     @if (row.moleculeType === 'ccd') {

--- a/src/app/features/workflows/single-prediction/single-prediction.html
+++ b/src/app/features/workflows/single-prediction/single-prediction.html
@@ -162,58 +162,148 @@
 
               <div class="min-w-0">
                 <label
-                  [for]="'sequence-' + row.id"
+                  [for]="'sequence-name-' + row.id"
                   class="mb-1 block text-sm font-medium"
                 >
                   Sequence
                 </label>
-                @if (row.moleculeType === 'ccd') {
-                <app-listbox-select
-                  [inputId]="'sequence-' + row.id"
-                  [options]="ccdOptions"
-                  [value]="row.sequence"
-                  [placeholder]="'Select a ligand...'"
-                  [invalid]="!!(shouldShowRowFieldError(row, 'sequence') && getRowErrors(i).sequence)"
-                  (valueChange)="updateRowSequence(row.id, $event)"
-                  (blurred)="touchRowField(row.id, 'sequence')"
-                ></app-listbox-select>
-                } @else {
-                <textarea
-                  [id]="'sequence-' + row.id"
-                  rows="1"
-                  spellcheck="false"
-                  autocomplete="off"
-                  autocorrect="off"
-                  autocapitalize="off"
-                  [value]="row.sequence"
-                  (input)="updateRowSequence(row.id, $any($event.target).value)"
-                  (blur)="touchRowField(row.id, 'sequence')"
-                  [class]="
-                    shouldShowRowFieldError(row, 'sequence') && getRowErrors(i).sequence
-                      ? 'border-red-500 focus:ring-red-100'
-                      : 'focus:ring-sky-100'
-                  "
-                  class="block min-h-10 max-h-40 w-full resize-none rounded-md border bg-white px-4 py-2 text-sm font-mono break-all text-gray-900 focus:outline-none focus:ring-2 transition-colors field-sizing-content"
-                  [placeholder]="
-                    row.moleculeType === 'ligand'
-                      ? 'CC(=O)OC1=CC=CC=C1C(=O)O'
-                      : row.moleculeType === 'dna'
-                        ? 'ATGCGT'
-                        : row.moleculeType === 'rna'
-                          ? 'AUGCGU'
-                          : 'ACDEFGHIKLMNPQRSTVWY'
-                  "
-                ></textarea>
-                } @if (shouldShowRowFieldError(row, 'sequence') &&
-                getRowErrors(i).sequence) {
-                <p class="mt-1 text-xs text-red-600" role="alert">
-                  {{ getRowErrors(i).sequence }}
-                </p>
-                } @if (shouldShowRowToolError(row) && getRowErrors(i).tool) {
-                <p class="mt-1 text-xs text-red-600" role="alert">
-                  {{ getRowErrors(i).tool }}
-                </p>
-                }
+
+                <!-- FASTA card wrapper: pt-2 pushes inner card down so floating label bisects its top border -->
+                <div class="relative pt-2">
+                  <!-- Floating label: sits on the inner card's top border -->
+                  <div
+                    class="absolute top-0 left-3 z-10 flex items-center gap-0.5 bg-white px-1"
+                  >
+                    <span
+                      class="shrink-0 select-none font-mono text-xs"
+                      [class]="
+                        shouldShowRowFieldError(row, 'name') && getRowErrors(i).name
+                          ? 'text-red-400'
+                          : 'text-gray-400'
+                      "
+                      aria-hidden="true"
+                      >&gt;</span
+                    >
+                    <input
+                      type="text"
+                      [id]="'sequence-name-' + row.id"
+                      [attr.aria-label]="'Sequence name for entity ' + (i + 1)"
+                      [value]="row.name"
+                      (input)="updateRowName(row.id, $any($event.target).value)"
+                      (blur)="touchRowField(row.id, 'name')"
+                      placeholder="sequence-name"
+                      [class]="
+                        shouldShowRowFieldError(row, 'name') && getRowErrors(i).name
+                          ? 'text-red-500 placeholder-red-300'
+                          : 'text-gray-700'
+                      "
+                      class="bg-transparent font-mono text-xs field-sizing-content min-w-16 max-w-48 placeholder-gray-400 focus:outline-none"
+                      autocomplete="off"
+                      spellcheck="false"
+                      autocorrect="off"
+                      autocapitalize="off"
+                    />
+                  </div>
+
+                  <!-- Card body (overflow-hidden keeps border-radius on footer) -->
+                  <div
+                    class="overflow-hidden rounded-md border transition-colors focus-within:ring-2"
+                    [class]="
+                      !row.name.trim()
+                        ? 'border-red-300 focus-within:ring-red-100'
+                        : 'border-gray-200 focus-within:ring-sky-100'
+                    "
+                  >
+                    <!-- Sequence body -->
+                    @if (row.moleculeType === 'ccd') {
+                    <div class="px-3 pt-4 pb-3">
+                      <app-listbox-select
+                        [inputId]="'sequence-' + row.id"
+                        [options]="ccdOptions"
+                        [value]="row.sequence"
+                        [placeholder]="'Select a ligand...'"
+                        [invalid]="!!(shouldShowRowFieldError(row, 'sequence') && getRowErrors(i).sequence)"
+                        (valueChange)="updateRowSequence(row.id, $event)"
+                        (blurred)="touchRowField(row.id, 'sequence')"
+                      ></app-listbox-select>
+                    </div>
+                    } @else {
+                    <textarea
+                      [id]="'sequence-' + row.id"
+                      spellcheck="false"
+                      autocomplete="off"
+                      autocorrect="off"
+                      autocapitalize="off"
+                      [value]="row.sequence"
+                      (input)="updateRowSequence(row.id, $any($event.target).value)"
+                      (blur)="touchRowField(row.id, 'sequence')"
+                      class="block w-full resize-none bg-white px-3 pt-4 pb-3 font-mono text-sm text-gray-900 placeholder-gray-400 focus:outline-none field-sizing-content min-h-20 max-h-48 break-all"
+                      [placeholder]="
+                        row.moleculeType === 'ligand'
+                          ? 'CC(=O)OC1=CC=CC=C1C(=O)O'
+                          : row.moleculeType === 'dna'
+                            ? 'ATGCGT'
+                            : row.moleculeType === 'rna'
+                              ? 'AUGCGU'
+                              : 'ACDEFGHIKLMNPQRSTVWY'
+                      "
+                    ></textarea>
+                    }
+
+                    <!-- Stats footer — shown only when there is a sequence -->
+                    @if (getNormalizedSequence(row)) {
+                    <div
+                      class="flex items-center justify-between border-t border-gray-100 bg-gray-50 px-3 py-2 text-xs"
+                    >
+                      @if (row.moleculeType !== 'ligand' && row.moleculeType !== 'ccd') {
+                      <span class="text-gray-500">
+                        Length:
+                        {{ getNormalizedSequence(row).length.toLocaleString() }} bp
+                      </span>
+                      } @else if (row.moleculeType === 'ccd' && ccdLookupNames()[row.id]) {
+                      <span class="font-medium text-gray-600">{{
+                        ccdLookupNames()[row.id]
+                      }}</span>
+                      } @else {
+                      <span></span>
+                      }
+                      <span
+                        class="flex items-center gap-1 font-medium"
+                        [class]="
+                          !getRowErrors(i).sequence && !getRowErrors(i).name
+                            ? 'text-emerald-600'
+                            : 'text-red-500'
+                        "
+                      >
+                        {{ !getRowErrors(i).sequence && !getRowErrors(i).name ? "✓" : "✗" }}
+                        {{ !getRowErrors(i).sequence && !getRowErrors(i).name ? "Valid" : "Invalid" }}
+                        {{ getMoleculeTypeLabel(row.moleculeType) }}
+                      </span>
+                    </div>
+                    }
+
+                    <!-- Sequence error -->
+                    @if (shouldShowRowFieldError(row, 'sequence') && getRowErrors(i).sequence) {
+                    <p
+                      class="border-t border-red-100 bg-red-50 px-3 py-2 text-xs text-red-600"
+                      role="alert"
+                    >
+                      {{ getRowErrors(i).sequence }}
+                    </p>
+                    }
+                  </div>
+
+                  @if (shouldShowRowFieldError(row, 'name') && getRowErrors(i).name) {
+                  <p class="mt-1 text-xs text-red-500" role="alert">
+                    {{ getRowErrors(i).name }}
+                  </p>
+                  }
+                  @if (shouldShowRowToolError(row) && getRowErrors(i).tool) {
+                  <p class="mt-1 text-xs text-red-600" role="alert">
+                    {{ getRowErrors(i).tool }}
+                  </p>
+                  }
+                </div>
               </div>
 
               <div class="flex flex-col items-center">

--- a/src/app/features/workflows/single-prediction/single-prediction.html
+++ b/src/app/features/workflows/single-prediction/single-prediction.html
@@ -202,7 +202,9 @@
                       autocorrect="off"
                       autocapitalize="off"
                     />
-                    <span class="shrink-0 select-none text-xs text-red-500" aria-hidden="true"
+                    <span
+                      class="shrink-0 select-none text-xs text-red-500"
+                      aria-hidden="true"
                       >*</span
                     >
                   </div>
@@ -257,28 +259,28 @@
                     <div
                       class="flex items-center justify-between border-t border-gray-100 bg-gray-50 px-3 py-2 text-xs"
                     >
-                      @if (row.moleculeType !== 'ligand' && row.moleculeType !== 'ccd') {
+                      @if (row.moleculeType !== 'ligand' && row.moleculeType !==
+                      'ccd') {
                       <span class="text-gray-500">
-                        Length:
-                        {{ getNormalizedSequence(row).length.toLocaleString() }} bp
+                        Length: {{
+                        getNormalizedSequence(row).length.toLocaleString() }} bp
                       </span>
-                      } @else if (row.moleculeType === 'ccd' && ccdLookupNames()[row.id]) {
-                      <span class="font-medium text-gray-600">{{
-                        ccdLookupNames()[row.id]
-                      }}</span>
+                      } @else if (row.moleculeType === 'ccd' &&
+                      ccdLookupNames()[row.id]) {
+                      <span class="font-medium text-gray-600"
+                        >{{ ccdLookupNames()[row.id] }}</span
+                      >
                       } @else {
                       <span></span>
-                      }
-                      @if (getRowErrors(i).name || getRowErrors(i).sequence) {
-                      <span class="flex items-center gap-1 font-medium text-red-500">
-                        ✗
-                        @if (getRowErrors(i).name && getRowErrors(i).sequence) {
-                          Header &amp; sequence invalid
-                        } @else if (getRowErrors(i).name) {
-                          Header {{ !row.name.trim() ? 'missing' : 'invalid' }}
-                        } @else {
-                          Sequence {{ !getNormalizedSequence(row) ? 'missing' : 'invalid' }}
-                        }
+                      } @if (getRowErrors(i).name || getRowErrors(i).sequence) {
+                      <span
+                        class="flex items-center gap-1 font-medium text-red-500"
+                      >
+                        ✗ @if (getRowErrors(i).name && getRowErrors(i).sequence)
+                        { Header &amp; sequence invalid } @else if
+                        (getRowErrors(i).name) { Header {{ !row.name.trim() ?
+                        'missing' : 'invalid' }} } @else { Sequence {{
+                        !getNormalizedSequence(row) ? 'missing' : 'invalid' }} }
                       </span>
                       } @else {
                       <span></span>
@@ -287,7 +289,8 @@
                     }
 
                     <!-- Sequence error -->
-                    @if (shouldShowRowFieldError(row, 'sequence') && getRowErrors(i).sequence) {
+                    @if (shouldShowRowFieldError(row, 'sequence') &&
+                    getRowErrors(i).sequence) {
                     <p
                       class="border-t border-red-100 bg-red-50 px-3 py-2 text-xs text-red-600"
                       role="alert"
@@ -297,12 +300,12 @@
                     }
                   </div>
 
-                  @if (shouldShowRowFieldError(row, 'name') && getRowErrors(i).name) {
+                  @if (shouldShowRowFieldError(row, 'name') &&
+                  getRowErrors(i).name) {
                   <p class="mt-1 text-xs text-red-500" role="alert">
                     {{ getRowErrors(i).name }}
                   </p>
-                  }
-                  @if (shouldShowRowToolError(row) && getRowErrors(i).tool) {
+                  } @if (shouldShowRowToolError(row) && getRowErrors(i).tool) {
                   <p class="mt-1 text-xs text-red-600" role="alert">
                     {{ getRowErrors(i).tool }}
                   </p>

--- a/src/app/features/workflows/single-prediction/single-prediction.html
+++ b/src/app/features/workflows/single-prediction/single-prediction.html
@@ -94,7 +94,7 @@
             cdkDragPreviewContainer="parent"
           >
             <div
-              class="grid gap-4 lg:grid-cols-[40px_170px_110px_minmax(0,1fr)_40px] lg:items-start"
+              class="grid gap-4 lg:grid-cols-[40px_170px_110px_170px_minmax(0,1fr)_40px] lg:items-start"
             >
               <div class="flex shrink-0 cursor-grab flex-col items-center">
                 <span class="mb-1 block text-sm font-medium">
@@ -165,152 +165,144 @@
                   [for]="'sequence-name-' + row.id"
                   class="mb-1 block text-sm font-medium"
                 >
+                  Sequence Name <span class="text-red-500">*</span>
+                </label>
+
+                <div
+                  class="flex h-10 items-center gap-1 rounded-md border bg-white px-3 transition-colors focus-within:ring-2"
+                  [class]="
+                    shouldShowRowFieldError(row, 'name') && getRowErrors(i).name
+                      ? 'border-red-300 focus-within:ring-red-100'
+                      : 'border-gray-200 focus-within:ring-sky-100'
+                  "
+                >
+                  <input
+                    type="text"
+                    [id]="'sequence-name-' + row.id"
+                    [attr.aria-label]="'Sequence name for entity ' + (i + 1)"
+                    [value]="row.name"
+                    (input)="updateRowName(row.id, $any($event.target).value)"
+                    (blur)="touchRowField(row.id, 'name')"
+                    [placeholder]="'seq' + (i + 1)"
+                    [class]="
+                      shouldShowRowFieldError(row, 'name') && getRowErrors(i).name
+                        ? 'text-red-500 placeholder-red-300'
+                        : 'text-gray-700'
+                    "
+                    class="min-w-0 flex-1 bg-transparent font-mono text-xs placeholder-gray-400 focus:outline-none"
+                    autocomplete="off"
+                    spellcheck="false"
+                    autocorrect="off"
+                    autocapitalize="off"
+                  />
+                </div>
+
+                @if (shouldShowRowFieldError(row, 'name') &&
+                getRowErrors(i).name) {
+                <p class="mt-1 text-xs text-red-500" role="alert">
+                  {{ getRowErrors(i).name }}
+                </p>
+                }
+              </div>
+
+              <div class="min-w-0">
+                <label
+                  [for]="'sequence-' + row.id"
+                  class="mb-1 block text-sm font-medium"
+                >
                   Sequence <span class="text-red-500">*</span>
                 </label>
 
-                <!-- FASTA card wrapper -->
-                <div class="relative">
-                  <div
-                    class="absolute top-0 left-3 z-10 flex items-center gap-0.5 bg-white px-1"
-                  >
-                    <span
-                      class="shrink-0 select-none font-mono text-xs"
-                      [class]="
-                        shouldShowRowFieldError(row, 'name') && getRowErrors(i).name
-                          ? 'text-red-400'
-                          : 'text-gray-400'
-                      "
-                      aria-hidden="true"
-                      >&gt;</span
-                    >
-                    <input
-                      type="text"
-                      [id]="'sequence-name-' + row.id"
-                      [attr.aria-label]="'Sequence name for entity ' + (i + 1)"
-                      [value]="row.name"
-                      (input)="updateRowName(row.id, $any($event.target).value)"
-                      (blur)="touchRowField(row.id, 'name')"
-                      placeholder="sequence-name"
-                      [class]="
-                        shouldShowRowFieldError(row, 'name') && getRowErrors(i).name
-                          ? 'text-red-500 placeholder-red-300'
-                          : 'text-gray-700'
-                      "
-                      class="bg-transparent font-mono text-xs field-sizing-content min-w-16 max-w-48 placeholder-gray-400 focus:outline-none"
-                      autocomplete="off"
-                      spellcheck="false"
-                      autocorrect="off"
-                      autocapitalize="off"
-                    />
-                    <span
-                      class="shrink-0 select-none text-xs text-red-500"
-                      aria-hidden="true"
-                      >*</span
-                    >
-                  </div>
+                @if (row.moleculeType === 'ccd') {
+                <app-listbox-select
+                  [inputId]="'sequence-' + row.id"
+                  [options]="ccdOptions"
+                  [value]="row.sequence"
+                  [placeholder]="'Select a ligand...'"
+                  [invalid]="!!(shouldShowRowFieldError(row, 'sequence') && getRowErrors(i).sequence)"
+                  (valueChange)="updateRowSequence(row.id, $event)"
+                  (blurred)="touchRowField(row.id, 'sequence')"
+                ></app-listbox-select>
 
-                  <div
-                    class="rounded-md border transition-colors focus-within:ring-2"
-                    [class]="
-                      (row.moleculeType === 'ccd' ? 'overflow-visible' : 'overflow-hidden') +
-                      ' ' +
-                      (shouldShowRowFieldError(row, 'name') && getRowErrors(i).name
-                        ? 'border-red-300 focus-within:ring-red-100'
-                        : 'border-gray-200 focus-within:ring-sky-100')
+                @if (shouldShowRowFieldError(row, 'sequence') &&
+                getRowErrors(i).sequence) {
+                <p class="mt-1 text-xs text-red-600" role="alert">
+                  {{ getRowErrors(i).sequence }}
+                </p>
+                }
+                } @else {
+                <div
+                  class="overflow-hidden rounded-md border transition-colors focus-within:ring-2"
+                  [class]="
+                    shouldShowRowFieldError(row, 'sequence') && getRowErrors(i).sequence
+                      ? 'border-red-300 focus-within:ring-red-100'
+                      : 'border-gray-200 focus-within:ring-sky-100'
+                  "
+                >
+                  <textarea
+                    [id]="'sequence-' + row.id"
+                    spellcheck="false"
+                    autocomplete="off"
+                    autocorrect="off"
+                    autocapitalize="off"
+                    [value]="row.sequence"
+                    (input)="updateRowSequence(row.id, $any($event.target).value)"
+                    (blur)="touchRowField(row.id, 'sequence')"
+                    class="block w-full resize-none bg-white px-3 py-2 font-mono text-sm text-gray-900 placeholder-gray-400 focus:outline-none field-sizing-content min-h-10 max-h-40 break-all"
+                    [placeholder]="
+                      row.moleculeType === 'ligand'
+                        ? 'CC(=O)OC1=CC=CC=C1C(=O)O'
+                        : row.moleculeType === 'dna'
+                          ? 'ATGCGT'
+                          : row.moleculeType === 'rna'
+                            ? 'AUGCGU'
+                            : 'ACDEFGHIKLMNPQRSTVWY'
                     "
+                  ></textarea>
+
+                  <!-- Stats footer — shown only when there is a sequence and length applies -->
+                  @if (getNormalizedSequence(row) && row.moleculeType !== 'ligand') {
+                  <div
+                    class="flex items-center justify-between border-t border-gray-100 bg-gray-50 px-3 py-2 text-xs"
                   >
-                    @if (row.moleculeType === 'ccd') {
-                    <div class="px-3 pt-4 pb-3">
-                      <app-listbox-select
-                        [inputId]="'sequence-' + row.id"
-                        [options]="ccdOptions"
-                        [value]="row.sequence"
-                        [placeholder]="'Select a ligand...'"
-                        [invalid]="!!(shouldShowRowFieldError(row, 'sequence') && getRowErrors(i).sequence)"
-                        (valueChange)="updateRowSequence(row.id, $event)"
-                        (blurred)="touchRowField(row.id, 'sequence')"
-                      ></app-listbox-select>
-                    </div>
+                    <span class="text-gray-500">
+                      Length: {{
+                      getNormalizedSequence(row).length.toLocaleString() }} bp
+                    </span>
+                    @if (getRowErrors(i).name || getRowErrors(i).sequence) {
+                    <span
+                      class="flex items-center gap-1 font-medium text-red-500"
+                    >
+                      ✗ @if (getRowErrors(i).name && getRowErrors(i).sequence)
+                      { Header &amp; sequence invalid } @else if
+                      (getRowErrors(i).name) { Header {{ !row.name.trim() ?
+                      'missing' : 'invalid' }} } @else { Sequence {{
+                      !getNormalizedSequence(row) ? 'missing' : 'invalid' }} }
+                    </span>
                     } @else {
-                    <textarea
-                      [id]="'sequence-' + row.id"
-                      spellcheck="false"
-                      autocomplete="off"
-                      autocorrect="off"
-                      autocapitalize="off"
-                      [value]="row.sequence"
-                      (input)="updateRowSequence(row.id, $any($event.target).value)"
-                      (blur)="touchRowField(row.id, 'sequence')"
-                      class="block w-full resize-none bg-white px-3 pt-4 pb-3 font-mono text-sm text-gray-900 placeholder-gray-400 focus:outline-none field-sizing-content min-h-10 max-h-40 break-all"
-                      [placeholder]="
-                        row.moleculeType === 'ligand'
-                          ? 'CC(=O)OC1=CC=CC=C1C(=O)O'
-                          : row.moleculeType === 'dna'
-                            ? 'ATGCGT'
-                            : row.moleculeType === 'rna'
-                              ? 'AUGCGU'
-                              : 'ACDEFGHIKLMNPQRSTVWY'
-                      "
-                    ></textarea>
-                    }
-
-                    <!-- Stats footer — shown only when there is a sequence -->
-                    @if (getNormalizedSequence(row)) {
-                    <div
-                      class="flex items-center justify-between border-t border-gray-100 bg-gray-50 px-3 py-2 text-xs"
-                    >
-                      @if (row.moleculeType !== 'ligand' && row.moleculeType !==
-                      'ccd') {
-                      <span class="text-gray-500">
-                        Length: {{
-                        getNormalizedSequence(row).length.toLocaleString() }} bp
-                      </span>
-                      } @else if (row.moleculeType === 'ccd' &&
-                      ccdLookupNames()[row.id]) {
-                      <span class="font-medium text-gray-600"
-                        >{{ ccdLookupNames()[row.id] }}</span
-                      >
-                      } @else {
-                      <span></span>
-                      } @if (getRowErrors(i).name || getRowErrors(i).sequence) {
-                      <span
-                        class="flex items-center gap-1 font-medium text-red-500"
-                      >
-                        ✗ @if (getRowErrors(i).name && getRowErrors(i).sequence)
-                        { Header &amp; sequence invalid } @else if
-                        (getRowErrors(i).name) { Header {{ !row.name.trim() ?
-                        'missing' : 'invalid' }} } @else { Sequence {{
-                        !getNormalizedSequence(row) ? 'missing' : 'invalid' }} }
-                      </span>
-                      } @else {
-                      <span></span>
-                      }
-                    </div>
-                    }
-
-                    <!-- Sequence error -->
-                    @if (shouldShowRowFieldError(row, 'sequence') &&
-                    getRowErrors(i).sequence) {
-                    <p
-                      class="border-t border-red-100 bg-red-50 px-3 py-2 text-xs text-red-600"
-                      role="alert"
-                    >
-                      {{ getRowErrors(i).sequence }}
-                    </p>
+                    <span></span>
                     }
                   </div>
+                  }
 
-                  @if (shouldShowRowFieldError(row, 'name') &&
-                  getRowErrors(i).name) {
-                  <p class="mt-1 text-xs text-red-500" role="alert">
-                    {{ getRowErrors(i).name }}
-                  </p>
-                  } @if (shouldShowRowToolError(row) && getRowErrors(i).tool) {
-                  <p class="mt-1 text-xs text-red-600" role="alert">
-                    {{ getRowErrors(i).tool }}
+                  <!-- Sequence error -->
+                  @if (shouldShowRowFieldError(row, 'sequence') &&
+                  getRowErrors(i).sequence) {
+                  <p
+                    class="border-t border-red-100 bg-red-50 px-3 py-2 text-xs text-red-600"
+                    role="alert"
+                  >
+                    {{ getRowErrors(i).sequence }}
                   </p>
                   }
                 </div>
+                }
+
+                @if (shouldShowRowToolError(row) && getRowErrors(i).tool) {
+                <p class="mt-1 text-xs text-red-600" role="alert">
+                  {{ getRowErrors(i).tool }}
+                </p>
+                }
               </div>
 
               <div class="flex flex-col items-center">

--- a/src/app/features/workflows/single-prediction/single-prediction.html
+++ b/src/app/features/workflows/single-prediction/single-prediction.html
@@ -169,7 +169,7 @@
                 </label>
 
                 <div
-                  class="flex h-10 items-center gap-1 rounded-md border bg-white px-3 transition-colors focus-within:ring-2"
+                  class="flex h-10 items-center gap-1 rounded-md border bg-white px-4 transition-colors focus-within:ring-2"
                   [class]="
                     shouldShowRowFieldError(row, 'name') && getRowErrors(i).name
                       ? 'border-red-500 focus-within:ring-red-100'
@@ -189,7 +189,7 @@
                         ? 'text-red-500 placeholder-red-300'
                         : 'text-gray-700'
                     "
-                    class="min-w-0 flex-1 bg-transparent font-mono text-xs placeholder-gray-400 focus:outline-none"
+                    class="min-w-0 flex-1 bg-transparent font-mono text-sm placeholder-gray-400 focus:outline-none"
                     autocomplete="off"
                     spellcheck="false"
                     autocorrect="off"
@@ -234,7 +234,7 @@
                 >
                   <div class="relative">
                     <div
-                      class="pointer-events-none absolute inset-0 overflow-hidden break-all px-3 py-2 font-mono text-sm text-gray-900"
+                      class="pointer-events-none absolute inset-0 overflow-hidden break-all px-4 py-2 font-mono text-sm text-gray-900"
                       aria-hidden="true"
                     >
                       @for (cell of getSequenceCells(row.sequence); track
@@ -260,7 +260,7 @@
                       (input)="updateRowSequence(row.id, $any($event.target).value)"
                       (scroll)="syncSequenceOverlayScroll($event)"
                       (blur)="touchRowField(row.id, 'sequence')"
-                      class="relative block w-full resize-none bg-transparent px-3 py-2 font-mono text-sm leading-7.5 tracking-[2px] text-transparent caret-gray-900 placeholder-gray-400 focus:outline-none field-sizing-content min-h-10 max-h-40 break-all"
+                      class="relative block w-full resize-none bg-transparent px-4 py-2 font-mono text-sm leading-7.5 tracking-[2px] text-transparent caret-gray-900 placeholder-gray-400 focus:outline-none field-sizing-content min-h-10 max-h-40 break-all"
                       [placeholder]="
                         row.moleculeType === 'ligand'
                           ? 'CC(=O)OC1=CC=CC=C1C(=O)O'

--- a/src/app/features/workflows/single-prediction/single-prediction.html
+++ b/src/app/features/workflows/single-prediction/single-prediction.html
@@ -199,7 +199,7 @@
 
                 @if (shouldShowRowFieldError(row, 'name') &&
                 getRowErrors(i).name) {
-                <p class="mt-1 text-xs text-red-500" role="alert">
+                <p class="mt-1 text-xs text-red-600" role="alert">
                   {{ getRowErrors(i).name }}
                 </p>
                 }
@@ -240,7 +240,7 @@
                 >
                   <div class="relative">
                     <div
-                      class="pointer-events-none absolute inset-0 overflow-hidden break-all px-3 py-2 font-mono text-[14px] text-gray-900"
+                      class="pointer-events-none absolute inset-0 overflow-hidden break-all px-3 py-2 font-mono text-sm text-gray-900"
                       aria-hidden="true"
                     >
                       @for (cell of getSequenceCells(row.sequence); track
@@ -270,7 +270,7 @@
                       (input)="updateRowSequence(row.id, $any($event.target).value)"
                       (scroll)="syncSequenceOverlayScroll($event)"
                       (blur)="touchRowField(row.id, 'sequence')"
-                      class="relative block w-full resize-none bg-transparent px-3 py-2 font-mono text-[14px] leading-7.5 tracking-[2px] text-transparent caret-gray-900 placeholder-gray-400 focus:outline-none field-sizing-content min-h-10 max-h-40 break-all"
+                      class="relative block w-full resize-none bg-transparent px-3 py-2 font-mono text-sm leading-7.5 tracking-[2px] text-transparent caret-gray-900 placeholder-gray-400 focus:outline-none field-sizing-content min-h-10 max-h-40 break-all"
                       [placeholder]="
                         row.moleculeType === 'ligand'
                           ? 'CC(=O)OC1=CC=CC=C1C(=O)O'

--- a/src/app/features/workflows/single-prediction/single-prediction.html
+++ b/src/app/features/workflows/single-prediction/single-prediction.html
@@ -172,7 +172,7 @@
                   class="flex h-10 items-center gap-1 rounded-md border bg-white px-3 transition-colors focus-within:ring-2"
                   [class]="
                     shouldShowRowFieldError(row, 'name') && getRowErrors(i).name
-                      ? 'border-red-300 focus-within:ring-red-100'
+                      ? 'border-red-500 focus-within:ring-red-100'
                       : 'border-gray-200 focus-within:ring-sky-100'
                   "
                 >
@@ -228,7 +228,7 @@
                   class="overflow-hidden rounded-md border transition-colors focus-within:ring-2"
                   [class]="
                     shouldShowRowFieldError(row, 'sequence') && getRowErrors(i).sequence
-                      ? 'border-red-300 focus-within:ring-red-100'
+                      ? 'border-red-500 focus-within:ring-red-100'
                       : 'border-gray-200 focus-within:ring-sky-100'
                   "
                 >
@@ -239,11 +239,7 @@
                     >
                       @for (cell of getSequenceCells(row.sequence); track
                       $index) {<span
-                        [class]="
-                          cell.label
-                            ? 'inline-block w-[1ch] align-top text-center mr-2'
-                            : 'inline-block w-[1ch] align-top text-center mr-0.5'
-                        "
+                        class="inline-block w-[1ch] align-top text-center mr-0.5"
                         ><span
                           class="block h-2.5 overflow-visible text-[9px] leading-2.5 whitespace-nowrap text-gray-400 select-none"
                           >{{ cell.label }}</span

--- a/src/app/features/workflows/single-prediction/single-prediction.html
+++ b/src/app/features/workflows/single-prediction/single-prediction.html
@@ -165,7 +165,7 @@
                   [for]="'sequence-name-' + row.id"
                   class="mb-1 block text-sm font-medium"
                 >
-                  Sequence
+                  Sequence <span class="text-red-500">*</span>
                 </label>
 
                 <!-- FASTA card wrapper -->
@@ -202,6 +202,9 @@
                       autocorrect="off"
                       autocapitalize="off"
                     />
+                    <span class="shrink-0 select-none text-xs text-red-500" aria-hidden="true"
+                      >*</span
+                    >
                   </div>
 
                   <div

--- a/src/app/features/workflows/single-prediction/single-prediction.html
+++ b/src/app/features/workflows/single-prediction/single-prediction.html
@@ -168,9 +168,8 @@
                   Sequence
                 </label>
 
-                <!-- FASTA card wrapper: pt-2 pushes inner card down so floating label bisects its top border -->
-                <div class="relative pt-2">
-                  <!-- Floating label: sits on the inner card's top border -->
+                <!-- FASTA card wrapper -->
+                <div class="relative">
                   <div
                     class="absolute top-0 left-3 z-10 flex items-center gap-0.5 bg-white px-1"
                   >
@@ -205,16 +204,14 @@
                     />
                   </div>
 
-                  <!-- Card body (overflow-hidden keeps border-radius on footer) -->
                   <div
                     class="overflow-hidden rounded-md border transition-colors focus-within:ring-2"
                     [class]="
-                      !row.name.trim()
+                      shouldShowRowFieldError(row, 'name') && getRowErrors(i).name
                         ? 'border-red-300 focus-within:ring-red-100'
                         : 'border-gray-200 focus-within:ring-sky-100'
                     "
                   >
-                    <!-- Sequence body -->
                     @if (row.moleculeType === 'ccd') {
                     <div class="px-3 pt-4 pb-3">
                       <app-listbox-select
@@ -237,7 +234,7 @@
                       [value]="row.sequence"
                       (input)="updateRowSequence(row.id, $any($event.target).value)"
                       (blur)="touchRowField(row.id, 'sequence')"
-                      class="block w-full resize-none bg-white px-3 pt-4 pb-3 font-mono text-sm text-gray-900 placeholder-gray-400 focus:outline-none field-sizing-content min-h-20 max-h-48 break-all"
+                      class="block w-full resize-none bg-white px-3 pt-4 pb-3 font-mono text-sm text-gray-900 placeholder-gray-400 focus:outline-none field-sizing-content min-h-10 max-h-40 break-all"
                       [placeholder]="
                         row.moleculeType === 'ligand'
                           ? 'CC(=O)OC1=CC=CC=C1C(=O)O'
@@ -267,18 +264,20 @@
                       } @else {
                       <span></span>
                       }
-                      <span
-                        class="flex items-center gap-1 font-medium"
-                        [class]="
-                          !getRowErrors(i).sequence && !getRowErrors(i).name
-                            ? 'text-emerald-600'
-                            : 'text-red-500'
-                        "
-                      >
-                        {{ !getRowErrors(i).sequence && !getRowErrors(i).name ? "✓" : "✗" }}
-                        {{ !getRowErrors(i).sequence && !getRowErrors(i).name ? "Valid" : "Invalid" }}
-                        {{ getMoleculeTypeLabel(row.moleculeType) }}
+                      @if (getRowErrors(i).name || getRowErrors(i).sequence) {
+                      <span class="flex items-center gap-1 font-medium text-red-500">
+                        ✗
+                        @if (getRowErrors(i).name && getRowErrors(i).sequence) {
+                          Header &amp; sequence invalid
+                        } @else if (getRowErrors(i).name) {
+                          Header {{ !row.name.trim() ? 'missing' : 'invalid' }}
+                        } @else {
+                          Sequence {{ !getNormalizedSequence(row) ? 'missing' : 'invalid' }}
+                        }
                       </span>
+                      } @else {
+                      <span></span>
+                      }
                     </div>
                     }
 

--- a/src/app/features/workflows/single-prediction/single-prediction.html
+++ b/src/app/features/workflows/single-prediction/single-prediction.html
@@ -206,12 +206,20 @@
               </div>
 
               <div class="min-w-0">
-                <label
-                  [for]="'sequence-' + row.id"
-                  class="mb-1 block text-sm font-medium"
-                >
-                  Sequence <span class="text-red-500">*</span>
-                </label>
+                <div class="mb-1 flex items-center justify-between gap-2">
+                  <label
+                    [for]="'sequence-' + row.id"
+                    class="text-sm font-medium"
+                  >
+                    Sequence <span class="text-red-500">*</span>
+                  </label>
+                  @if (getNormalizedSequence(row) && row.moleculeType !== 'ligand' && row.moleculeType !== 'ccd') {
+                  <span class="text-xs text-gray-400">
+                    {{ getNormalizedSequence(row).length.toLocaleString() }}
+                    {{ row.moleculeType === 'protein' ? 'aa' : 'nt' }}
+                  </span>
+                  }
+                </div>
 
                 @if (row.moleculeType === 'ccd') {
                 <app-listbox-select
@@ -259,31 +267,6 @@
                             : 'ACDEFGHIKLMNPQRSTVWY'
                     "
                   ></textarea>
-
-                  <!-- Stats footer — shown only when there is a sequence and length applies -->
-                  @if (getNormalizedSequence(row) && row.moleculeType !== 'ligand') {
-                  <div
-                    class="flex items-center justify-between border-t border-gray-100 bg-gray-50 px-3 py-2 text-xs"
-                  >
-                    <span class="text-gray-500">
-                      Length: {{
-                      getNormalizedSequence(row).length.toLocaleString() }} bp
-                    </span>
-                    @if (getRowErrors(i).name || getRowErrors(i).sequence) {
-                    <span
-                      class="flex items-center gap-1 font-medium text-red-500"
-                    >
-                      ✗ @if (getRowErrors(i).name && getRowErrors(i).sequence)
-                      { Header &amp; sequence invalid } @else if
-                      (getRowErrors(i).name) { Header {{ !row.name.trim() ?
-                      'missing' : 'invalid' }} } @else { Sequence {{
-                      !getNormalizedSequence(row) ? 'missing' : 'invalid' }} }
-                    </span>
-                    } @else {
-                    <span></span>
-                    }
-                  </div>
-                  }
 
                   <!-- Sequence error -->
                   @if (shouldShowRowFieldError(row, 'sequence') &&

--- a/src/app/features/workflows/single-prediction/single-prediction.html
+++ b/src/app/features/workflows/single-prediction/single-prediction.html
@@ -229,8 +229,7 @@
                 <p class="mt-1 text-xs text-red-600" role="alert">
                   {{ getRowErrors(i).sequence }}
                 </p>
-                }
-                } @else {
+                } } @else {
                 <div
                   class="overflow-hidden rounded-md border transition-colors focus-within:ring-2"
                   [class]="
@@ -254,9 +253,9 @@
                         ><span
                           class="block h-2.5 overflow-visible text-[9px] leading-2.5 whitespace-nowrap text-gray-400 select-none"
                           >{{ cell.label }}</span
-                        ><span class="block leading-5">{{
-                          cell.char
-                        }}</span></span
+                        ><span class="block leading-5"
+                          >{{ cell.char }}</span
+                        ></span
                       >}
                     </div>
 
@@ -291,10 +290,7 @@
                 <p class="mt-1 text-xs text-red-600" role="alert">
                   {{ getRowErrors(i).sequence }}
                 </p>
-                }
-                }
-
-                @if (shouldShowRowToolError(row) && getRowErrors(i).tool) {
+                } } @if (shouldShowRowToolError(row) && getRowErrors(i).tool) {
                 <p class="mt-1 text-xs text-red-600" role="alert">
                   {{ getRowErrors(i).tool }}
                 </p>

--- a/src/app/features/workflows/single-prediction/single-prediction.html
+++ b/src/app/features/workflows/single-prediction/single-prediction.html
@@ -206,20 +206,12 @@
               </div>
 
               <div class="min-w-0">
-                <div class="mb-1 flex items-center justify-between gap-2">
-                  <label
-                    [for]="'sequence-' + row.id"
-                    class="text-sm font-medium"
-                  >
-                    Sequence <span class="text-red-500">*</span>
-                  </label>
-                  @if (getNormalizedSequence(row) && row.moleculeType !== 'ligand' && row.moleculeType !== 'ccd') {
-                  <span class="text-xs text-gray-400">
-                    {{ getNormalizedSequence(row).length.toLocaleString() }}
-                    {{ row.moleculeType === 'protein' ? 'aa' : 'nt' }}
-                  </span>
-                  }
-                </div>
+                <label
+                  [for]="'sequence-' + row.id"
+                  class="mb-1 block text-sm font-medium"
+                >
+                  Sequence <span class="text-red-500">*</span>
+                </label>
 
                 @if (row.moleculeType === 'ccd') {
                 <app-listbox-select
@@ -247,38 +239,59 @@
                       : 'border-gray-200 focus-within:ring-sky-100'
                   "
                 >
-                  <textarea
-                    [id]="'sequence-' + row.id"
-                    spellcheck="false"
-                    autocomplete="off"
-                    autocorrect="off"
-                    autocapitalize="off"
-                    [value]="row.sequence"
-                    (input)="updateRowSequence(row.id, $any($event.target).value)"
-                    (blur)="touchRowField(row.id, 'sequence')"
-                    class="block w-full resize-none bg-white px-3 py-2 font-mono text-sm text-gray-900 placeholder-gray-400 focus:outline-none field-sizing-content min-h-10 max-h-40 break-all"
-                    [placeholder]="
-                      row.moleculeType === 'ligand'
-                        ? 'CC(=O)OC1=CC=CC=C1C(=O)O'
-                        : row.moleculeType === 'dna'
-                          ? 'ATGCGT'
-                          : row.moleculeType === 'rna'
-                            ? 'AUGCGU'
-                            : 'ACDEFGHIKLMNPQRSTVWY'
-                    "
-                  ></textarea>
+                  <div class="relative">
+                    <div
+                      class="pointer-events-none absolute inset-0 overflow-hidden break-all px-3 py-2 font-mono text-[14px] text-gray-900"
+                      aria-hidden="true"
+                    >
+                      @for (cell of getSequenceCells(row.sequence); track
+                      $index) {<span
+                        [class]="
+                          cell.label
+                            ? 'inline-block w-[1ch] align-top text-center mr-2'
+                            : 'inline-block w-[1ch] align-top text-center mr-0.5'
+                        "
+                        ><span
+                          class="block h-2.5 overflow-visible text-[9px] leading-2.5 whitespace-nowrap text-gray-400 select-none"
+                          >{{ cell.label }}</span
+                        ><span class="block leading-5">{{
+                          cell.char
+                        }}</span></span
+                      >}
+                    </div>
 
-                  <!-- Sequence error -->
-                  @if (shouldShowRowFieldError(row, 'sequence') &&
-                  getRowErrors(i).sequence) {
-                  <p
-                    class="border-t border-red-100 bg-red-50 px-3 py-2 text-xs text-red-600"
-                    role="alert"
-                  >
-                    {{ getRowErrors(i).sequence }}
-                  </p>
-                  }
+                    <textarea
+                      [id]="'sequence-' + row.id"
+                      [attr.aria-label]="'Sequence for entity ' + (i + 1)"
+                      spellcheck="false"
+                      autocomplete="off"
+                      autocorrect="off"
+                      autocapitalize="off"
+                      [value]="row.sequence"
+                      (input)="updateRowSequence(row.id, $any($event.target).value)"
+                      (scroll)="syncSequenceOverlayScroll($event)"
+                      (blur)="touchRowField(row.id, 'sequence')"
+                      class="relative block w-full resize-none bg-transparent px-3 py-2 font-mono text-[14px] leading-7.5 tracking-[2px] text-transparent caret-gray-900 placeholder-gray-400 focus:outline-none field-sizing-content min-h-10 max-h-40 break-all"
+                      [placeholder]="
+                        row.moleculeType === 'ligand'
+                          ? 'CC(=O)OC1=CC=CC=C1C(=O)O'
+                          : row.moleculeType === 'dna'
+                            ? 'ATGCGT'
+                            : row.moleculeType === 'rna'
+                              ? 'AUGCGU'
+                              : 'ACDEFGHIKLMNPQRSTVWY'
+                      "
+                    ></textarea>
+                  </div>
                 </div>
+
+                <!-- Sequence error -->
+                @if (shouldShowRowFieldError(row, 'sequence') &&
+                getRowErrors(i).sequence) {
+                <p class="mt-1 text-xs text-red-600" role="alert">
+                  {{ getRowErrors(i).sequence }}
+                </p>
+                }
                 }
 
                 @if (shouldShowRowToolError(row) && getRowErrors(i).tool) {

--- a/src/app/features/workflows/single-prediction/single-prediction.html
+++ b/src/app/features/workflows/single-prediction/single-prediction.html
@@ -168,34 +168,25 @@
                   Sequence Name <span class="text-red-500">*</span>
                 </label>
 
-                <div
-                  class="flex h-10 items-center gap-1 rounded-md border bg-white px-4 transition-colors focus-within:ring-2"
+                <input
+                  type="text"
+                  [id]="'sequence-name-' + row.id"
+                  [attr.aria-label]="'Sequence name for entity ' + (i + 1)"
+                  [value]="row.name"
+                  (input)="updateRowName(row.id, $any($event.target).value)"
+                  (blur)="touchRowField(row.id, 'name')"
+                  [placeholder]="'seq' + (i + 1)"
                   [class]="
                     shouldShowRowFieldError(row, 'name') && getRowErrors(i).name
-                      ? 'border-red-500 focus-within:ring-red-100'
-                      : 'border-gray-200 focus-within:ring-sky-100'
+                      ? 'border-red-500 focus:ring-red-100'
+                      : 'focus:ring-sky-100'
                   "
-                >
-                  <input
-                    type="text"
-                    [id]="'sequence-name-' + row.id"
-                    [attr.aria-label]="'Sequence name for entity ' + (i + 1)"
-                    [value]="row.name"
-                    (input)="updateRowName(row.id, $any($event.target).value)"
-                    (blur)="touchRowField(row.id, 'name')"
-                    [placeholder]="'seq' + (i + 1)"
-                    [class]="
-                      shouldShowRowFieldError(row, 'name') && getRowErrors(i).name
-                        ? 'text-red-500 placeholder-red-300'
-                        : 'text-gray-700'
-                    "
-                    class="min-w-0 flex-1 bg-transparent font-mono text-sm placeholder-gray-400 focus:outline-none"
-                    autocomplete="off"
-                    spellcheck="false"
-                    autocorrect="off"
-                    autocapitalize="off"
-                  />
-                </div>
+                  class="block h-10 w-full rounded-md border bg-white px-4 font-mono text-sm text-gray-900 placeholder-gray-400 focus:outline-none focus:ring-2 transition-colors"
+                  autocomplete="off"
+                  spellcheck="false"
+                  autocorrect="off"
+                  autocapitalize="off"
+                />
 
                 @if (shouldShowRowFieldError(row, 'name') &&
                 getRowErrors(i).name) {

--- a/src/app/features/workflows/single-prediction/single-prediction.spec.ts
+++ b/src/app/features/workflows/single-prediction/single-prediction.spec.ts
@@ -128,6 +128,7 @@ describe("SinglePredictionComponent", () => {
   ): number {
     const rowId = component.entityRows()[0].id;
     component.jobName.set("test-run");
+    component.updateRowName(rowId, "pro");
     component.updateRowSequence(rowId, sequence);
     component.updateRowCopyNumber(rowId, copyNumber);
     component.updateRowMoleculeType(rowId, "protein");
@@ -214,6 +215,7 @@ describe("SinglePredictionComponent", () => {
   it("should validate DNA, RNA, and ligand formats", () => {
     const rowId = component.entityRows()[0].id;
     component.jobName.set("test-run");
+    component.updateRowName(rowId, "entity1");
     component.selectTool("boltz");
 
     component.updateRowSequence(rowId, "ACGT");
@@ -245,6 +247,7 @@ describe("SinglePredictionComponent", () => {
   it("should mark CCD row valid when code is in the supported list", () => {
     const rowId = component.entityRows()[0].id;
     component.jobName.set("test-run");
+    component.updateRowName(rowId, "ccdrow");
     component.selectTool("boltz");
     component.updateRowMoleculeType(rowId, "ccd");
     component.updateRowSequence(rowId, "ATP");
@@ -356,6 +359,7 @@ describe("SinglePredictionComponent", () => {
   it("should allow Boltz with non-protein molecules and generate FASTA-like content", () => {
     const rowId = component.entityRows()[0].id;
     component.jobName.set("test-run");
+    component.updateRowName(rowId, "dna");
 
     component.selectTool("boltz");
     component.updateRowSequence(rowId, "ACGT");
@@ -363,8 +367,27 @@ describe("SinglePredictionComponent", () => {
     component.updateRowCopyNumber(rowId, "2");
 
     expect(component.isStep1Valid()).toBe(true);
-    expect(component.generatedFastaContent()).toContain(">dna_1");
-    expect(component.generatedFastaContent()).toContain(">dna_2");
+    expect(component.generatedFastaContent()).toContain(">dna_1|dna");
+    expect(component.generatedFastaContent()).toContain(">dna_2|dna");
+  });
+
+  it("should tag generated FASTA headers with the molecule type", () => {
+    const rowId = component.entityRows()[0].id;
+    component.jobName.set("test-run");
+    component.selectTool("boltz");
+
+    component.updateRowName(rowId, "seq1");
+    component.updateRowSequence(rowId, "ACDEFGHIK");
+    component.updateRowMoleculeType(rowId, "protein");
+    expect(component.generatedFastaContent()).toBe(">seq1|protein\nACDEFGHIK");
+
+    component.updateRowSequence(rowId, "CC(=O)O");
+    component.updateRowMoleculeType(rowId, "ligand");
+    expect(component.generatedFastaContent()).toBe(">seq1|smiles\nCC(=O)O");
+
+    component.updateRowSequence(rowId, "ATP");
+    component.updateRowMoleculeType(rowId, "ccd");
+    expect(component.generatedFastaContent()).toBe(">seq1|ccd\nATP");
   });
 
   it("should normalize protein sequence content in summary", () => {
@@ -619,8 +642,18 @@ describe("SinglePredictionComponent", () => {
     expect(errors["copyNumber"]).toContain("greater than or equal to 1");
   });
 
+  it("should reject sequence names containing underscores", () => {
+    const rowId = component.entityRows()[0].id;
+    component.updateRowSequence(rowId, "ACDEFGHIK");
+    component.updateRowName(rowId, "seq_1");
+
+    const errors = component.entityValidationResults()[0];
+    expect(errors.name).toContain("underscore");
+  });
+
   it("should require jobName in step 1 validation", () => {
     const rowId = component.entityRows()[0].id;
+    component.updateRowName(rowId, "entity1");
     component.updateRowSequence(rowId, "ACDEFGHIK");
 
     component.jobName.set("");
@@ -668,6 +701,7 @@ describe("SinglePredictionComponent", () => {
 
   it("should keep input-config invalid until jobName is filled", () => {
     const rowId = component.entityRows()[0].id;
+    component.updateRowName(rowId, "entity1");
     component.updateRowSequence(rowId, "ACDEFGHIK");
     component.jobName.set("");
     expect(component.isSectionValid("input-config")).toBe(false);

--- a/src/app/features/workflows/single-prediction/single-prediction.ts
+++ b/src/app/features/workflows/single-prediction/single-prediction.ts
@@ -86,6 +86,11 @@ interface ToolSettingErrors {
   colabfoldNumRecycles?: string;
 }
 
+interface SequenceCell {
+  char: string;
+  label: string;
+}
+
 @Component({
   selector: "app-single-prediction",
   imports: [
@@ -684,6 +689,26 @@ export default class SinglePredictionComponent extends WorkflowPageBase {
     }
 
     return {};
+  }
+
+  /** 1-based position labels for the sequence ruler overlay: every 10th character and the last one. */
+  getSequenceCells(sequence: string): SequenceCell[] {
+    const length = sequence.length;
+    return Array.from(sequence, (char, index) => {
+      const position = index + 1;
+      const label =
+        position % 10 === 0 || position === length ? String(position) : "";
+      return { char, label };
+    });
+  }
+
+  /** Keeps the decorative position-ruler layer scrolled in sync with the real textarea beneath it. */
+  syncSequenceOverlayScroll(event: Event): void {
+    const textarea = event.target as HTMLTextAreaElement;
+    const overlay = textarea.previousElementSibling as HTMLElement | null;
+    if (overlay) {
+      overlay.scrollTop = textarea.scrollTop;
+    }
   }
 
   getNormalizedSequence(row: EntityRow): string {

--- a/src/app/features/workflows/single-prediction/single-prediction.ts
+++ b/src/app/features/workflows/single-prediction/single-prediction.ts
@@ -251,10 +251,11 @@ export default class SinglePredictionComponent extends WorkflowPageBase {
       const copies = this.getParsedCopyNumber(row.copyNumber);
       const sequence = this.getNormalizedSequence(row);
       const name = row.name.trim();
+      const type = this.getFastaMoleculeType(row.moleculeType);
 
       for (let copyIndex = 0; copyIndex < copies; copyIndex += 1) {
         const headerId = copies > 1 ? `${name}_${copyIndex + 1}` : name;
-        fastaRecords.push(`>${headerId}\n${sequence}`);
+        fastaRecords.push(`>${headerId}|${type}\n${sequence}`);
       }
     }
 
@@ -486,6 +487,11 @@ export default class SinglePredictionComponent extends WorkflowPageBase {
     return (
       this.moleculeTypes.find((item) => item.value === type)?.label ?? type
     );
+  }
+
+  /** Maps an entity's molecule type to the FASTA header type tag (e.g. `>name|protein`). */
+  private getFastaMoleculeType(type: MoleculeType): string {
+    return type === "ligand" ? "smiles" : type;
   }
 
   private createEntityRow(): EntityRow {

--- a/src/app/features/workflows/single-prediction/single-prediction.ts
+++ b/src/app/features/workflows/single-prediction/single-prediction.ts
@@ -39,6 +39,7 @@ import {
   isValidSmiles,
   lookupCcdCompound,
   validateDnaSequence,
+  validateFastaHeader,
   validateProteinSequence,
   validateRnaSequence,
 } from "../shared/fasta.utils";
@@ -61,10 +62,12 @@ interface ToolChip extends ToolOption {
 
 interface EntityRow {
   id: number;
+  name: string;
   sequence: string;
   copyNumber: string;
   moleculeType: MoleculeType;
   touched: {
+    name: boolean;
     sequence: boolean;
     copyNumber: boolean;
     moleculeType: boolean;
@@ -72,6 +75,7 @@ interface EntityRow {
 }
 
 interface EntityRowErrors {
+  name?: string;
   sequence?: string;
   copyNumber?: string;
   tool?: string;
@@ -189,7 +193,8 @@ export default class SinglePredictionComponent extends WorkflowPageBase {
       !this.jobNameError() &&
       this.entityRows().length > 0 &&
       this.entityValidationResults().every(
-        (errors) => !errors.sequence && !errors.copyNumber && !errors.tool
+        (errors) =>
+          !errors.name && !errors.sequence && !errors.copyNumber && !errors.tool
       )
   );
   readonly isStep2Valid = computed(
@@ -219,7 +224,7 @@ export default class SinglePredictionComponent extends WorkflowPageBase {
     const entityItems = this.entityRows().map((row, index) => {
       const sequence = this.getNormalizedSequence(row);
       return {
-        label: `Entity ${index + 1}`,
+        label: row.name.trim() || `Entity ${index + 1}`,
         value: sequence
           ? `${this.getMoleculeTypeLabel(
               row.moleculeType
@@ -241,20 +246,15 @@ export default class SinglePredictionComponent extends WorkflowPageBase {
     }
 
     const fastaRecords: string[] = [];
-    let sequenceNumber = 1;
 
     for (const row of this.entityRows()) {
       const copies = this.getParsedCopyNumber(row.copyNumber);
       const sequence = this.getNormalizedSequence(row);
+      const name = row.name.trim();
 
       for (let copyIndex = 0; copyIndex < copies; copyIndex += 1) {
-        fastaRecords.push(
-          [
-            `>${this.getFastaSequenceId(row.moleculeType, sequenceNumber)}`,
-            sequence,
-          ].join("\n")
-        );
-        sequenceNumber += 1;
+        const headerId = copies > 1 ? `${name}_${copyIndex + 1}` : name;
+        fastaRecords.push(`>${headerId}\n${sequence}`);
       }
     }
 
@@ -315,6 +315,10 @@ export default class SinglePredictionComponent extends WorkflowPageBase {
 
   updateRowCopyNumber(id: number, value: string): void {
     this.patchRow(id, { copyNumber: value });
+  }
+
+  updateRowName(id: number, value: string): void {
+    this.patchRow(id, { name: value });
   }
 
   updateRowMoleculeType(id: number, value: string): void {
@@ -485,12 +489,15 @@ export default class SinglePredictionComponent extends WorkflowPageBase {
   }
 
   private createEntityRow(): EntityRow {
+    const id = this.nextRowId++;
     return {
-      id: this.nextRowId++,
+      id,
+      name: "",
       sequence: "",
       copyNumber: "1",
       moleculeType: "protein",
       touched: {
+        name: false,
         sequence: false,
         copyNumber: false,
         moleculeType: false,
@@ -553,6 +560,7 @@ export default class SinglePredictionComponent extends WorkflowPageBase {
       rows.map((row) => ({
         ...row,
         touched: {
+          name: true,
           sequence: true,
           copyNumber: true,
           moleculeType: true,
@@ -569,6 +577,15 @@ export default class SinglePredictionComponent extends WorkflowPageBase {
 
   private validateEntityRow(row: EntityRow): EntityRowErrors {
     const errors: EntityRowErrors = {};
+
+    const otherNames = this.entityRows()
+      .filter((r) => r.id !== row.id)
+      .map((r) => r.name);
+    const headerValidation = validateFastaHeader(row.name, otherNames);
+    if (!headerValidation.valid) {
+      errors.name = headerValidation.errorMessage;
+    }
+
     const normalizedSequence = this.getNormalizedSequence(row);
 
     if (
@@ -663,7 +680,7 @@ export default class SinglePredictionComponent extends WorkflowPageBase {
     return {};
   }
 
-  private getNormalizedSequence(row: EntityRow): string {
+  getNormalizedSequence(row: EntityRow): string {
     if (row.moleculeType === "ligand") {
       return row.sequence.trim();
     }
@@ -776,8 +793,8 @@ export default class SinglePredictionComponent extends WorkflowPageBase {
       workflow: "single-prediction",
       tool: this.selectedTool(),
       runName: this.jobName().trim(),
-      entities: this.entityRows().map((row, index) => ({
-        id: `entity_${index + 1}`,
+      entities: this.entityRows().map((row) => ({
+        id: row.name.trim(),
         moleculeType: row.moleculeType,
         copyNumber: this.getParsedCopyNumber(row.copyNumber),
         sequence: this.getNormalizedSequence(row),
@@ -785,20 +802,6 @@ export default class SinglePredictionComponent extends WorkflowPageBase {
       fastaContent: this.generatedFastaContent(),
       ...this.buildToolSettingsPayload(),
     };
-  }
-
-  private getFastaSequenceId(
-    type: MoleculeType,
-    sequenceNumber: number
-  ): string {
-    const prefixes: Record<MoleculeType, string> = {
-      protein: "pro",
-      rna: "rna",
-      dna: "dna",
-      ligand: "ligand",
-      ccd: "ccd",
-    };
-    return `${prefixes[type]}_${sequenceNumber}`;
   }
 
   private validateSequenceByMoleculeType(


### PR DESCRIPTION
<!--
Thank you for contributing! Please fill out the sections below to help maintainers review your change faster.
Delete any sections that don't apply.
-->

# Pull Request

## Summary

[SBP-458](https://biocloud.atlassian.net/browse/SBP-458) — Replaces auto-generated FASTA header IDs (e.g. `pro_1`) with a required, user-editable sequence name, tags each header with its molecule type (e.g. `>seq1|protein`), and adds a character-position ruler above the sequence input.

## Changes

- Added a required `name` field per entity row, validated (non-empty, no spaces/underscores, unique) via `validateFastaHeader`.
- FASTA headers now use the user-entered name and append `|type` (ligand → `smiles`); removed the old `getFastaSequenceId` generator.
- Submission payload entity `id` now uses the row name instead of `entity_N`.
- Added a position ruler above the sequence textarea: shows the 1-based residue position above every 10th character and above the final character, with a wider gap after each group of 10 for readability. Implemented as a decorative overlay layer (`getSequenceCells`) behind a transparent, fully-editable textarea so native typing/selection/paste/scroll behaviour is preserved; scroll position is kept in sync via `syncSequenceOverlayScroll`.
- Updated specs to cover the new field, validation, and header format.
- **Breaking:** consumers relying on old `pro_1`/`entity_N` IDs need to account for user-supplied names and the `|type` suffix.
- 
<img width="1505" height="845" alt="Screenshot 2026-07-08 at 12 14 42 pm" src="https://github.com/user-attachments/assets/34f4bec8-ea19-4111-8669-c8c6586cc07a" />

<img width="1505" height="845" alt="Screenshot 2026-07-08 at 12 16 40 pm" src="https://github.com/user-attachments/assets/5e342be6-9c79-488f-9648-4293df487fc7" />


## How to Test

1. Open Single Prediction — each entity row now shows a `>` name input; blank/spaced/underscored or duplicate names show a validation error.
2. Set copy number > 1 and check generated FASTA headers look like `>name_1|protein`.
3. Switch molecule type to Ligand (SMILES/CCD) and confirm the tag becomes `|smiles` / `|ccd`.
4. Open the CCD dropdown and confirm it's no longer clipped.
5. Type/paste a sequence longer than 10 characters and confirm position numbers appear above every 10th character and the last character, that wrapped lines keep labels attached to the correct row, and that typing/selecting/scrolling in the field still behaves like a normal textarea.
6. `npm test` and `npm run prettier:check` pass.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added or updated documentation where necessary
- [x] I have run linting and unit tests locally
- [x] The code follows the project's style guidelines


[SBP-458]: https://biocloud.atlassian.net/browse/SBP-458?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ