### PR TITLE
ci(release-please): track dev and staging instead of main

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -2,7 +2,7 @@ name: release-please
 
 on:
   push:
-    branches: [main]
+    branches: [dev, staging]
   workflow_dispatch:
 
 permissions:
@@ -24,6 +24,9 @@ jobs:
         with:
           release-type: node
           package-name: sbp-portal
+          # Maintain a separate release line per integration branch: a push to
+          # dev manages the dev release PR, a push to staging manages staging's.
+          target-branch: ${{ github.ref_name }}
           token: ${{ steps.app-token.outputs.token }}
           changelog-types: |
             [


### PR DESCRIPTION
Retire the main-based release line. release-please now runs on pushes to dev and staging and manages a separate release PR per branch (target-branch = the pushed branch).

<!--
Thank you for contributing! Please fill out the sections below to help maintainers review your change faster.
Delete any sections that don't apply.
-->

# Pull Request

## Summary

Update release-please target branches

## Changes

- Update CI workflow for release-please to target `dev` and `staging` branches. After this PR is merged into `dev`, `dev` release-please works immediately.

## How to Test

CI tests shall pass

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added or updated documentation where necessary
- [ ] I have run linting and unit tests locally
- [ ] The code follows the project's style guidelines
