### PR TITLE
feat: enable RFDiffusion, add 8 residues validation, remove compress length range

### DIFF
--- a/src/app/core/configs/themes.config.ts
+++ b/src/app/core/configs/themes.config.ts
@@ -38,7 +38,6 @@ export const THEMES: ThemeConfig[] = [
             id: "rfdiffusion",
             label: "RFdiffusion",
             href: "/binder-design/de-novo-design",
-            disabled: true,
           },
         ],
       },

--- a/src/app/features/themes/binder-design/binder-design.spec.ts
+++ b/src/app/features/themes/binder-design/binder-design.spec.ts
@@ -89,7 +89,7 @@ describe("BinderDesignComponent", () => {
       expect(rfdiffusionTool).toBeDefined();
       expect(rfdiffusionTool?.id).toBe("rfdiffusion");
       expect(rfdiffusionTool?.href).toBe("/binder-design/de-novo-design");
-      expect(rfdiffusionTool?.disabled).toBeTrue();
+      expect(rfdiffusionTool?.disabled).toBeFalsy();
     });
 
     it("should have all tools with required properties", () => {

--- a/src/app/features/workflows/components/molstar-viewer/molstar-viewer.component.ts
+++ b/src/app/features/workflows/components/molstar-viewer/molstar-viewer.component.ts
@@ -239,10 +239,9 @@ export class MolstarViewerComponent implements AfterViewInit, OnDestroy {
         // Suppress echo-back while we are applying an external selection.
         if (this._applyingExternalSelection) return;
         const residues = this.readCurrentSelection(selMgr);
-        const compressed = this.compressToRanges(residues);
         this.zone.run(() => {
-          this.selectedResidues.set(compressed);
-          this.residuesSelected.emit(compressed.join(","));
+          this.selectedResidues.set(residues);
+          this.residuesSelected.emit(residues.join(","));
         });
       });
     } catch {
@@ -456,48 +455,6 @@ export class MolstarViewerComponent implements AfterViewInit, OnDestroy {
     } catch {
       /* non-critical */
     }
-  }
-
-  /**
-   * Collapse runs of consecutive same-chain residues into range notation.
-   * e.g. ["A12","A13","A14","B5"] → ["A12-A14","B5"]
-   */
-  private compressToRanges(residues: string[]): string[] {
-    if (residues.length === 0) return [];
-
-    type Parsed = { chain: string; seq: number; label: string };
-    const parsed: (Parsed | null)[] = residues.map((label) => {
-      const p = this.parseResidueLabel(label);
-      return p ? { ...p, label } : null;
-    });
-
-    const result: string[] = [];
-    let i = 0;
-    while (i < parsed.length) {
-      const cur = parsed[i];
-      if (!cur) {
-        result.push(residues[i++]);
-        continue;
-      }
-
-      let j = i + 1;
-      while (j < parsed.length) {
-        const prev = parsed[j - 1] as Parsed;
-        const next = parsed[j];
-        if (!next || next.chain !== cur.chain || next.seq !== prev.seq + 1)
-          break;
-        j++;
-      }
-
-      const last = parsed[j - 1] as Parsed;
-      result.push(
-        j - i === 1
-          ? cur.label
-          : `${cur.chain}${cur.seq}-${last.chain}${last.seq}`
-      );
-      i = j;
-    }
-    return result;
   }
 
   /** Prevent any <button> inside the viewer from submitting the parent form.

--- a/src/app/features/workflows/components/molstar-viewer/molstar-viewer.component.ts
+++ b/src/app/features/workflows/components/molstar-viewer/molstar-viewer.component.ts
@@ -55,7 +55,7 @@ export class MolstarViewerComponent implements AfterViewInit, OnDestroy {
   disabled = input(false);
   /** Programmatically select residues from outside (e.g. manual form input).
    *  Accepts the same comma-separated token format the viewer emits:
-   *  "A56,B12" or ranges "A12-A14". Set to "" to clear the selection. */
+   *  "A56,B12". Set to "" to clear the selection. */
   externalSelection = input("");
   /** Round the viewport's bottom-right corner. Set when the viewer meets the
    *  container's right edge (e.g. the config panel is collapsed); the WebGL
@@ -252,7 +252,7 @@ export class MolstarViewerComponent implements AfterViewInit, OnDestroy {
   }
 
   /** Programmatically select the residues described by a comma-separated token
-   *  string (e.g. "A56,B12" or ranges "A12-A14").  Suppresses the outgoing
+   *  string (e.g. "A56,B12").  Suppresses the outgoing
    *  residuesSelected event so the parent form is not overwritten. */
   private async applyExternalSelection(residueString: string): Promise<void> {
     if (!this.plugin || this.status() !== "loaded") return;

--- a/src/app/features/workflows/de-novo-design/de-novo-design.html
+++ b/src/app/features/workflows/de-novo-design/de-novo-design.html
@@ -35,12 +35,6 @@
           [selectedToolId]="selectedTool()"
           (toolSelect)="selectTool($event)"
         ></app-tool-selection>
-        <div
-          class="rounded-md border border-amber-200 bg-amber-50 p-4 text-sm text-amber-800"
-        >
-          Only <strong>BindCraft</strong> is available right now. {{
-          unavailableToolLabels.join(" and ") }} are temporarily unavailable.
-        </div>
       </app-step-content>
     </div>
 

--- a/src/app/features/workflows/de-novo-design/de-novo-design.spec.ts
+++ b/src/app/features/workflows/de-novo-design/de-novo-design.spec.ts
@@ -426,6 +426,39 @@ describe("DeNovoDesignComponent", () => {
       ).toContain("End residue 14");
     });
 
+    it("accepts exactly 8 hotspot residues", () => {
+      component.updateRowValueWithValidation(
+        "row1",
+        "target_hotspot_residues",
+        "A1,A2,A3,A4,A5,A6,A7,A8"
+      );
+      expect(
+        component.getRowFieldError("row1", "target_hotspot_residues")
+      ).toBeNull();
+    });
+
+    it("rejects more than 8 individual hotspot residues", () => {
+      component.updateRowValueWithValidation(
+        "row1",
+        "target_hotspot_residues",
+        "A1,A2,A3,A4,A5,A6,A7,A8,A9"
+      );
+      expect(
+        component.getRowFieldError("row1", "target_hotspot_residues")
+      ).toContain("Too many hotspot residues");
+    });
+
+    it("rejects a range that expands past 8 residues", () => {
+      component.updateRowValueWithValidation(
+        "row1",
+        "target_hotspot_residues",
+        "A1-A9"
+      );
+      expect(
+        component.getRowFieldError("row1", "target_hotspot_residues")
+      ).toContain("Too many hotspot residues");
+    });
+
     it("sets an error when the schema validator rejects the value", () => {
       schemaLoader.inputSchemaService.validateFieldValue.and.returnValue({
         valid: false,

--- a/src/app/features/workflows/de-novo-design/de-novo-design.spec.ts
+++ b/src/app/features/workflows/de-novo-design/de-novo-design.spec.ts
@@ -166,18 +166,14 @@ describe("DeNovoDesignComponent", () => {
       expect(component.selectedToolHasParams()).toBe(false);
     });
 
-    it("blocks selecting an unavailable tool and shows an error", () => {
+    it("allows selecting rfdiffusion", () => {
       component.selectTool("rfdiffusion");
-      expect(component.selectedTool()).toBe("bindcraft");
-      expect(component.showAlert()).toBe(true);
-      expect(component.alertMessage()).toContain("not available");
+      expect(component.selectedTool()).toBe("rfdiffusion");
     });
 
-    it("allows selecting the available tool", () => {
+    it("allows selecting bindcraft", () => {
       component.selectTool("bindcraft");
       expect(component.selectedTool()).toBe("bindcraft");
-      expect(component.isToolAvailable("bindcraft")).toBe(true);
-      expect(component.isToolAvailable("rfdiffusion")).toBe(false);
     });
   });
 

--- a/src/app/features/workflows/de-novo-design/de-novo-design.ts
+++ b/src/app/features/workflows/de-novo-design/de-novo-design.ts
@@ -673,6 +673,40 @@ export default class DeNovoDesignComponent
 
     this.workflowSubmission.isSubmitting.set(true);
 
+    // rfdiffusion has no samplesheet - it takes the PDB file directly, so skip
+    // the CSV-samplesheet-generating dataset upload and reuse the PDB's own S3
+    // URI (already synced into formData.starting_pdb) as the launch's s3InputKey.
+    if (this.selectedTool() === "rfdiffusion") {
+      const s3InputKey = (formData as Record<string, unknown>)[
+        "starting_pdb"
+      ] as string | undefined;
+      if (!s3InputKey) {
+        console.error("No PDB file uploaded for rfdiffusion submission");
+        this.workflowSubmission.isSubmitting.set(false);
+        this.showError("Please upload a PDB file before submitting.");
+        return;
+      }
+
+      const workflowFormData: DeNovoDesignPayload = {
+        ...formData,
+        workflow: "de-novo-design",
+        tool: this.selectedTool(),
+      };
+
+      this.workflowSubmission.submitWorkflowWithDataset(
+        workflowFormData,
+        s3InputKey,
+        (error) => {
+          console.error("Workflow launch failed", error);
+          this.workflowSubmission.isSubmitting.set(false);
+          this.showError(
+            `Workflow launch failed: ${error.message || "Unknown error"}`
+          );
+        }
+      );
+      return;
+    }
+
     this.datasetUploadService
       .uploadDataset({
         formData,

--- a/src/app/features/workflows/de-novo-design/de-novo-design.ts
+++ b/src/app/features/workflows/de-novo-design/de-novo-design.ts
@@ -89,8 +89,6 @@ export default class DeNovoDesignComponent
   extends WorkflowPageBase
   implements OnInit, OnDestroy
 {
-  private readonly availableToolId: ToolChip["id"] = "bindcraft";
-
   // // Make Object available in template
   Object = Object;
 
@@ -160,19 +158,9 @@ export default class DeNovoDesignComponent
       label: "BindCraft",
     },
   ];
-  readonly unavailableToolLabels: string[] = this.tools
-    .filter((tool) => tool.id !== this.availableToolId)
-    .map((tool) => tool.label);
   selectedTool = signal<ToolChip["id"]>("bindcraft");
   isToolSelected = (id: ToolChip["id"]) => this.selectedTool() === id;
-  isToolAvailable = (id: ToolChip["id"]) => id === this.availableToolId;
   selectTool(id: ToolChip["id"]) {
-    if (!this.isToolAvailable(id)) {
-      const label = this.tools.find((tool) => tool.id === id)?.label ?? id;
-      this.showError(`${label} is not available yet. Please use BindCraft.`);
-      this.selectedTool.set(this.availableToolId);
-      return;
-    }
     this.selectedTool.set(id);
   }
   selectedToolLabel: Signal<string> = computed(

--- a/src/app/features/workflows/de-novo-design/de-novo-design.ts
+++ b/src/app/features/workflows/de-novo-design/de-novo-design.ts
@@ -410,7 +410,6 @@ export default class DeNovoDesignComponent
         return `Residue ${parsed.resStart} not found in chain "${parsed.chain}"`;
       }
 
-      
       if (
         parsed.resStart !== parsed.resEnd &&
         !chainResidues.has(parsed.resEnd)

--- a/src/app/features/workflows/de-novo-design/de-novo-design.ts
+++ b/src/app/features/workflows/de-novo-design/de-novo-design.ts
@@ -55,6 +55,9 @@ interface ToolChip extends ToolOption {
   id: Extract<WorkflowTool, "bindcraft" | "rfdiffusion">;
 }
 
+/** Both bindcraft and rfdiffusion only support up to this many hotspot residues. */
+const MAX_HOTSPOT_RESIDUES = 8;
+
 @Component({
   selector: "app-de-novo-design",
   imports: [
@@ -313,7 +316,7 @@ export default class DeNovoDesignComponent
     this.updateRowValueWithValidation(rowId, "target_hotspot_residues", "");
   }
 
-  /** Return sorted, deduplicated chain letters from a residue string like "A56,B12-B20". */
+  /** Return sorted, deduplicated chain letters from a residue string like "A56,B12,B13". */
   private chainsFromResidues(residues: string): string {
     return [
       ...new Set(
@@ -378,14 +381,21 @@ export default class DeNovoDesignComponent
     if (!value?.trim()) return null;
     const residueMap = this.pdbResidueMap();
 
+    let residueCount = 0;
     for (const token of value
       .split(",")
       .map((t) => t.trim())
       .filter(Boolean)) {
       const parsed = MolstarViewerComponent.parseResidueToken(token);
       if (!parsed) {
-        return `Invalid format "${token}". Use chain+residue notation, e.g. "A56" or "A12-A14"`;
+        return `Invalid format "${token}". Use chain+residue notation, e.g. "A56" or "A56,A57"`;
       }
+
+      residueCount += Math.abs(parsed.resEnd - parsed.resStart) + 1;
+      if (residueCount > MAX_HOTSPOT_RESIDUES) {
+        return `Too many hotspot residues selected (${residueCount}). Only up to ${MAX_HOTSPOT_RESIDUES} are supported - remove some to continue.`;
+      }
+
       if (!residueMap) continue;
 
       const chainResidues = residueMap.get(parsed.chain);
@@ -399,6 +409,8 @@ export default class DeNovoDesignComponent
       if (!chainResidues.has(parsed.resStart)) {
         return `Residue ${parsed.resStart} not found in chain "${parsed.chain}"`;
       }
+
+      
       if (
         parsed.resStart !== parsed.resEnd &&
         !chainResidues.has(parsed.resEnd)


### PR DESCRIPTION
<!--
Thank you for contributing! Please fill out the sections below to help maintainers review your change faster.
Delete any sections that don't apply.
-->

# Pull Request

## Summary

[SBP-486](https://biocloud.atlassian.net/browse/SBP-486) — Turns on RFdiffusion as a selectable tool for the De Novo Design workflow (previously shown but disabled), and wires its submission path through to the backend.

## Changes

- Removed the "only BindCraft is available" banner and the tool-selection guard that forced the selection back to BindCraft; RFdiffusion is now a real, selectable tool.
- `themes.config.ts`: de-novo-design's RFdiffusion tool entry is no longer `disabled`.
- RFdiffusion submission path: since it takes a PDB file directly (no samplesheet), submission now skips the CSV dataset-upload step and reuses the uploaded PDB's own S3 URI as the launch's `s3InputKey`.
- Added a shared max-8 hotspot-residue validation for both BindCraft and RFdiffusion.
- Removed residue-range compression (`compressToRanges`) from the shared Mol* viewer — selections are now emitted and validated as individual residues (e.g. `A56,A57`) instead of compressed ranges (`A56-A57`), matching the hotspot format both tools expect.
- Updated specs to match (tool-enablement, submission path, hotspot-count validation).

## How to Test

1. Open Binder Design → De Novo Design; confirm the "coming soon" banner is gone and RFdiffusion is selectable alongside BindCraft.
2. Select RFdiffusion, upload a PDB, and submit; confirm it launches without a dataset/samplesheet upload step.
3. Select more than 8 hotspot residues and confirm a validation error blocks submission.
4. Select residues in the Mol* viewer and confirm the hotspot field lists them individually rather than as compressed ranges.
5. `npm test` and `npm run prettier:check` pass.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added or updated documentation where necessary
- [x] I have run linting and unit tests locally
- [x] The code follows the project's style guidelines


[SBP-486]: https://biocloud.atlassian.net/browse/SBP-486?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ