### PR TITLE
fix: de novo design hotspot residues placeholder

### DIFF
--- a/src/app/features/workflows/services/input-schema.service.spec.ts
+++ b/src/app/features/workflows/services/input-schema.service.spec.ts
@@ -646,9 +646,7 @@ describe("InputSchemaService", () => {
       // Verify the actual placeholder generation logic
       expect(lengthField?.placeholder).toBe("Enter a number"); // integer type takes precedence
       expect(residuesField?.placeholder).toBe("e.g., 1,2 or A1,A10,B1,B20"); // residues-specific pattern
-      expect(residuesOnlyField?.placeholder).toBe(
-        "e.g., 1,2 or A1,A10,B1,B20"
-      ); // residues-specific pattern
+      expect(residuesOnlyField?.placeholder).toBe("e.g., 1,2 or A1,A10,B1,B20"); // residues-specific pattern
       expect(chainsField?.placeholder).toBe("e.g., A,B or ABC"); // chains-specific pattern
       expect(nameField?.placeholder).toBe("Enter protein name");
       expect(idField?.placeholder).toBe("Enter sequence id");

--- a/src/app/features/workflows/services/input-schema.service.spec.ts
+++ b/src/app/features/workflows/services/input-schema.service.spec.ts
@@ -645,9 +645,9 @@ describe("InputSchemaService", () => {
 
       // Verify the actual placeholder generation logic
       expect(lengthField?.placeholder).toBe("Enter a number"); // integer type takes precedence
-      expect(residuesField?.placeholder).toBe("e.g., 1,2-10 or A1-10,B1-20"); // residues-specific pattern
+      expect(residuesField?.placeholder).toBe("e.g., 1,2 or A1,A10,B1,B20"); // residues-specific pattern
       expect(residuesOnlyField?.placeholder).toBe(
-        "e.g., 1,2-10 or A1-10,B1-20"
+        "e.g., 1,2 or A1,A10,B1,B20"
       ); // residues-specific pattern
       expect(chainsField?.placeholder).toBe("e.g., A,B or ABC"); // chains-specific pattern
       expect(nameField?.placeholder).toBe("Enter protein name");
@@ -903,7 +903,7 @@ describe("InputSchemaService", () => {
       const residuesField = fields.find((f) => f.name === "pure_residues");
 
       expect(lengthField?.placeholder).toBe("Enter length value"); // Still matches length condition
-      expect(residuesField?.placeholder).toBe("e.g., 1,2-10 or A1-10,B1-20"); // residues-specific pattern
+      expect(residuesField?.placeholder).toBe("e.g., 1,2 or A1,A10,B1,B20"); // residues-specific pattern
     });
   });
 
@@ -1055,7 +1055,7 @@ describe("InputSchemaService", () => {
       const residuesField = fields!.find(
         (f) => f.name === "residues_selection"
       );
-      expect(residuesField?.placeholder).toBe("e.g., 1,2-10 or A1-10,B1-20");
+      expect(residuesField?.placeholder).toBe("e.g., 1,2 or A1,A10,B1,B20");
     });
 
     it("should return empty array when bindflow schema lacks items.properties (line 407)", () => {

--- a/src/app/features/workflows/services/input-schema.service.ts
+++ b/src/app/features/workflows/services/input-schema.service.ts
@@ -347,7 +347,7 @@ export class InputSchemaService {
       return prop.default ? `Default: ${prop.default}` : "Enter a number";
     }
     if (key.includes("residues")) {
-      return "e.g., 1,2-10 or A1-10,B1-20";
+      return "e.g., 1,2 or A1,A10,B1,B20";
     }
     if (key.includes("chains")) {
       return "e.g., A,B or ABC";


### PR DESCRIPTION
We now disable combined range in hotspot selection. This PR aims to fix the hotspot residues placeholder to be consistent with selected hotspot residues.

<img width="1058" height="1050" alt="image" src="https://github.com/user-attachments/assets/cc487936-e89e-4858-b31c-1fa8692e7cfe" />
