### PR TITLE
fix: selected hotspot residues validation

### DIFF
--- a/src/app/features/workflows/services/input-schema.service.spec.ts
+++ b/src/app/features/workflows/services/input-schema.service.spec.ts
@@ -1253,9 +1253,7 @@ describe("InputSchemaService", () => {
         },
       };
 
-      expect(service.validateFieldValue(field, "A1,A2,B1,B2").valid).toBe(
-        true
-      );
+      expect(service.validateFieldValue(field, "A1,A2,B1,B2").valid).toBe(true);
     });
   });
 

--- a/src/app/features/workflows/services/input-schema.service.spec.ts
+++ b/src/app/features/workflows/services/input-schema.service.spec.ts
@@ -1097,7 +1097,7 @@ describe("InputSchemaService", () => {
             (f) => f.name === "target_hotspot_residues"
           );
           expect(field?.validation?.pattern).toBe(
-            "^[A-Za-z]{0,2}\\d+(\\s*,\\s*[A-Za-z]{0,2}\\d+)*$"
+            "^[A-Za-z]{0,3}\\d+(\\s*,\\s*[A-Za-z]{0,3}\\d+)*$"
           );
           done();
         },
@@ -1124,7 +1124,7 @@ describe("InputSchemaService", () => {
         next: (parsed) => {
           const field = parsed.sections[0].fields[0];
           expect(field.validation?.pattern).toBe(
-            "^[A-Za-z]{0,2}\\d+(\\s*,\\s*[A-Za-z]{0,2}\\d+)*$"
+            "^[A-Za-z]{0,3}\\d+(\\s*,\\s*[A-Za-z]{0,3}\\d+)*$"
           );
           done();
         },
@@ -1152,7 +1152,7 @@ describe("InputSchemaService", () => {
         name: "target_hotspot_residues",
         type: "string",
         validation: {
-          pattern: "^[A-Za-z]{0,2}\\d+(\\s*,\\s*[A-Za-z]{0,2}\\d+)*$",
+          pattern: "^[A-Za-z]{0,3}\\d+(\\s*,\\s*[A-Za-z]{0,3}\\d+)*$",
         },
       };
 
@@ -1170,13 +1170,92 @@ describe("InputSchemaService", () => {
         name: "target_hotspot_residues",
         type: "string",
         validation: {
-          pattern: "^[A-Za-z]{0,2}\\d+(\\s*,\\s*[A-Za-z]{0,2}\\d+)*$",
+          pattern: "^[A-Za-z]{0,3}\\d+(\\s*,\\s*[A-Za-z]{0,3}\\d+)*$",
         },
       };
 
       expect(service.validateFieldValue(field, "A56-A60").valid).toBe(false);
       expect(service.validateFieldValue(field, "acdef10").valid).toBe(false);
       expect(service.validateFieldValue(field, "A1,,B2").valid).toBe(false);
+    });
+
+    it("applies the uniqueItems override when parsing JSON Schema properties", (done) => {
+      const rawSchema = {
+        properties: {
+          target_hotspot_residues: { type: "string" },
+          chains: { type: "string" },
+        },
+      };
+
+      service.parseInputSchema(rawSchema).subscribe({
+        next: (parsed) => {
+          const hotspotField = parsed.sections[0].fields.find(
+            (f) => f.name === "target_hotspot_residues"
+          );
+          const chainsField = parsed.sections[0].fields.find(
+            (f) => f.name === "chains"
+          );
+          expect(hotspotField?.validation?.uniqueItems).toBe(true);
+          expect(chainsField?.validation?.uniqueItems).toBeUndefined();
+          done();
+        },
+      });
+    });
+
+    it("applies the uniqueItems override when parsing sections/fields format", (done) => {
+      const rawSchema = {
+        sections: [
+          {
+            name: "section1",
+            fields: [{ name: "target_hotspot_residues", type: "string" }],
+          },
+        ],
+      };
+
+      service.parseInputSchema(rawSchema).subscribe({
+        next: (parsed) => {
+          expect(parsed.sections[0].fields[0].validation?.uniqueItems).toBe(
+            true
+          );
+          done();
+        },
+      });
+    });
+
+    it("rejects duplicate residue tokens, case-insensitively", () => {
+      const field: InputSchemaField = {
+        name: "target_hotspot_residues",
+        type: "string",
+        validation: {
+          pattern: "^[A-Za-z]{0,3}\\d+(\\s*,\\s*[A-Za-z]{0,3}\\d+)*$",
+          uniqueItems: true,
+        },
+      };
+
+      const result1 = service.validateFieldValue(field, "A1,A2,A1");
+      expect(result1.valid).toBe(false);
+      expect(result1.errors[0]).toContain('duplicate value: "A1"');
+
+      const result2 = service.validateFieldValue(field, "A1,a1");
+      expect(result2.valid).toBe(false);
+
+      const result3 = service.validateFieldValue(field, "A1, A2, A1");
+      expect(result3.valid).toBe(false);
+    });
+
+    it("accepts residue tokens that are all unique", () => {
+      const field: InputSchemaField = {
+        name: "target_hotspot_residues",
+        type: "string",
+        validation: {
+          pattern: "^[A-Za-z]{0,3}\\d+(\\s*,\\s*[A-Za-z]{0,3}\\d+)*$",
+          uniqueItems: true,
+        },
+      };
+
+      expect(service.validateFieldValue(field, "A1,A2,B1,B2").valid).toBe(
+        true
+      );
     });
   });
 

--- a/src/app/features/workflows/services/input-schema.service.spec.ts
+++ b/src/app/features/workflows/services/input-schema.service.spec.ts
@@ -1080,6 +1080,106 @@ describe("InputSchemaService", () => {
     });
   });
 
+  describe("target_hotspot_residues validation override", () => {
+    it("applies the comma-only pattern override when parsing JSON Schema properties", (done) => {
+      const rawSchema = {
+        properties: {
+          target_hotspot_residues: {
+            type: "string",
+            pattern: "^.*$", // schema-provided pattern should be overridden
+          },
+        },
+      };
+
+      service.parseInputSchema(rawSchema).subscribe({
+        next: (parsed) => {
+          const field = parsed.sections[0].fields.find(
+            (f) => f.name === "target_hotspot_residues"
+          );
+          expect(field?.validation?.pattern).toBe(
+            "^[A-Za-z]{0,2}\\d+(\\s*,\\s*[A-Za-z]{0,2}\\d+)*$"
+          );
+          done();
+        },
+      });
+    });
+
+    it("applies the comma-only pattern override when parsing sections/fields format", (done) => {
+      const rawSchema = {
+        sections: [
+          {
+            name: "section1",
+            fields: [
+              {
+                name: "target_hotspot_residues",
+                type: "string",
+                validation: { pattern: "^.*$" },
+              },
+            ],
+          },
+        ],
+      };
+
+      service.parseInputSchema(rawSchema).subscribe({
+        next: (parsed) => {
+          const field = parsed.sections[0].fields[0];
+          expect(field.validation?.pattern).toBe(
+            "^[A-Za-z]{0,2}\\d+(\\s*,\\s*[A-Za-z]{0,2}\\d+)*$"
+          );
+          done();
+        },
+      });
+    });
+
+    it("does not apply the override to other fields", (done) => {
+      const rawSchema = {
+        properties: {
+          chains: { type: "string" },
+        },
+      };
+
+      service.parseInputSchema(rawSchema).subscribe({
+        next: (parsed) => {
+          const field = parsed.sections[0].fields[0];
+          expect(field.validation?.pattern).toBeUndefined();
+          done();
+        },
+      });
+    });
+
+    it("accepts comma-separated chain+residue tokens, with or without spaces", () => {
+      const field: InputSchemaField = {
+        name: "target_hotspot_residues",
+        type: "string",
+        validation: {
+          pattern: "^[A-Za-z]{0,2}\\d+(\\s*,\\s*[A-Za-z]{0,2}\\d+)*$",
+        },
+      };
+
+      expect(service.validateFieldValue(field, "A1,A10,B1,B20").valid).toBe(
+        true
+      );
+      expect(service.validateFieldValue(field, "A1, A20, B2, B30").valid).toBe(
+        true
+      );
+      expect(service.validateFieldValue(field, "1,2").valid).toBe(true);
+    });
+
+    it("rejects hyphen-separated ranges and malformed chain codes", () => {
+      const field: InputSchemaField = {
+        name: "target_hotspot_residues",
+        type: "string",
+        validation: {
+          pattern: "^[A-Za-z]{0,2}\\d+(\\s*,\\s*[A-Za-z]{0,2}\\d+)*$",
+        },
+      };
+
+      expect(service.validateFieldValue(field, "A56-A60").valid).toBe(false);
+      expect(service.validateFieldValue(field, "acdef10").valid).toBe(false);
+      expect(service.validateFieldValue(field, "A1,,B2").valid).toBe(false);
+    });
+  });
+
   describe("section and field fallbacks", () => {
     it("should apply sensible fallbacks when section and field metadata is missing", (done) => {
       const rawSchema = {

--- a/src/app/features/workflows/services/input-schema.service.ts
+++ b/src/app/features/workflows/services/input-schema.service.ts
@@ -245,12 +245,11 @@ export class InputSchemaService {
    * "<chain><residue>" tokens for hotspot residues — no hyphen/range
    * separators, and no chain codes longer than 2 characters like "acdef10").
    */
-  private static readonly VALIDATION_PATTERN_OVERRIDES: Record<
-    string,
-    string
-  > = {
-    target_hotspot_residues: "^[A-Za-z]{0,2}\\d+(\\s*,\\s*[A-Za-z]{0,2}\\d+)*$",
-  };
+  private static readonly VALIDATION_PATTERN_OVERRIDES: Record<string, string> =
+    {
+      target_hotspot_residues:
+        "^[A-Za-z]{0,2}\\d+(\\s*,\\s*[A-Za-z]{0,2}\\d+)*$",
+    };
 
   private parseFields(fields: Record<string, unknown>[]): InputSchemaField[] {
     return fields.map((field) => {
@@ -271,8 +270,7 @@ export class InputSchemaService {
         default: this.getDefaultValue(field.default),
         options: this.getOptionsValue(field.options || field.enum),
         validation: {
-          ...(typeof field.validation === "object" &&
-          field.validation !== null
+          ...(typeof field.validation === "object" && field.validation !== null
             ? (field.validation as Record<string, unknown>)
             : {}),
           ...(InputSchemaService.VALIDATION_PATTERN_OVERRIDES[name]

--- a/src/app/features/workflows/services/input-schema.service.ts
+++ b/src/app/features/workflows/services/input-schema.service.ts
@@ -18,6 +18,7 @@ export interface InputSchemaField {
     maxLength?: number;
     pattern?: string;
     format?: string;
+    uniqueItems?: boolean;
   };
   placeholder?: string;
   help_text?: string;
@@ -243,13 +244,21 @@ export class InputSchemaService {
    * Field-specific validation pattern overrides. Used to enforce stricter
    * formats than whatever the source schema provides (e.g. comma-separated
    * "<chain><residue>" tokens for hotspot residues — no hyphen/range
-   * separators, and no chain codes longer than 2 characters like "acdef10").
+   * separators, and no chain codes longer than 3 characters like "acdef10").
    */
   private static readonly VALIDATION_PATTERN_OVERRIDES: Record<string, string> =
     {
       target_hotspot_residues:
-        "^[A-Za-z]{0,2}\\d+(\\s*,\\s*[A-Za-z]{0,2}\\d+)*$",
+        "^[A-Za-z]{0,3}\\d+(\\s*,\\s*[A-Za-z]{0,3}\\d+)*$",
     };
+
+  /**
+   * Fields whose comma-separated tokens must each be unique (case-insensitive).
+   * Enforced by validateFieldValue alongside VALIDATION_PATTERN_OVERRIDES.
+   */
+  private static readonly UNIQUE_ITEMS_FIELDS = new Set<string>([
+    "target_hotspot_residues",
+  ]);
 
   private parseFields(fields: Record<string, unknown>[]): InputSchemaField[] {
     return fields.map((field) => {
@@ -275,6 +284,9 @@ export class InputSchemaService {
             : {}),
           ...(InputSchemaService.VALIDATION_PATTERN_OVERRIDES[name]
             ? { pattern: InputSchemaService.VALIDATION_PATTERN_OVERRIDES[name] }
+            : {}),
+          ...(InputSchemaService.UNIQUE_ITEMS_FIELDS.has(name)
+            ? { uniqueItems: true }
             : {}),
         },
         placeholder: this.getStringValue(field.placeholder) || "",
@@ -327,6 +339,9 @@ export class InputSchemaService {
             InputSchemaService.VALIDATION_PATTERN_OVERRIDES[key] ||
             this.getStringValue(prop.pattern),
           format: this.getStringValue(prop.format),
+          uniqueItems: InputSchemaService.UNIQUE_ITEMS_FIELDS.has(key)
+            ? true
+            : undefined,
         },
         placeholder:
           Array.isArray(prop.examples) && prop.examples.length > 0
@@ -503,6 +518,22 @@ export class InputSchemaService {
   }
 
   /**
+   * Return the first comma-separated token (trimmed, case-insensitively)
+   * that repeats in the given value, or undefined if all tokens are unique.
+   */
+  private findDuplicateToken(value: string): string | undefined {
+    const seen = new Set<string>();
+    for (const rawToken of value.split(",")) {
+      const token = rawToken.trim();
+      if (!token) continue;
+      const normalized = token.toUpperCase();
+      if (seen.has(normalized)) return token;
+      seen.add(normalized);
+    }
+    return undefined;
+  }
+
+  /**
    * Validate a field value against its schema
    */
   validateFieldValue(
@@ -558,6 +589,16 @@ export class InputSchemaService {
             !new RegExp(field.validation.pattern).test(value)
           ) {
             errors.push(`${field.label || field.name} format is invalid`);
+          }
+          if (field.validation?.uniqueItems) {
+            const duplicate = this.findDuplicateToken(value);
+            if (duplicate) {
+              errors.push(
+                `${
+                  field.label || field.name
+                } has a duplicate value: "${duplicate}"`
+              );
+            }
           }
         }
         break;

--- a/src/app/features/workflows/services/input-schema.service.ts
+++ b/src/app/features/workflows/services/input-schema.service.ts
@@ -239,6 +239,19 @@ export class InputSchemaService {
     starting_pdb: "Target PDB",
   };
 
+  /**
+   * Field-specific validation pattern overrides. Used to enforce stricter
+   * formats than whatever the source schema provides (e.g. comma-separated
+   * "<chain><residue>" tokens for hotspot residues — no hyphen/range
+   * separators, and no chain codes longer than 2 characters like "acdef10").
+   */
+  private static readonly VALIDATION_PATTERN_OVERRIDES: Record<
+    string,
+    string
+  > = {
+    target_hotspot_residues: "^[A-Za-z]{0,2}\\d+(\\s*,\\s*[A-Za-z]{0,2}\\d+)*$",
+  };
+
   private parseFields(fields: Record<string, unknown>[]): InputSchemaField[] {
     return fields.map((field) => {
       const name = this.getStringValue(field.name) || "unnamed_field";
@@ -257,10 +270,15 @@ export class InputSchemaService {
         required: typeof field.required === "boolean" ? field.required : false,
         default: this.getDefaultValue(field.default),
         options: this.getOptionsValue(field.options || field.enum),
-        validation:
-          typeof field.validation === "object" && field.validation !== null
+        validation: {
+          ...(typeof field.validation === "object" &&
+          field.validation !== null
             ? (field.validation as Record<string, unknown>)
-            : {},
+            : {}),
+          ...(InputSchemaService.VALIDATION_PATTERN_OVERRIDES[name]
+            ? { pattern: InputSchemaService.VALIDATION_PATTERN_OVERRIDES[name] }
+            : {}),
+        },
         placeholder: this.getStringValue(field.placeholder) || "",
         help_text: this.getStringValue(field.help_text) || "",
         fa_icon: this.getStringValue(field.fa_icon) || "",
@@ -307,7 +325,9 @@ export class InputSchemaService {
             typeof prop.minLength === "number" ? prop.minLength : undefined,
           maxLength:
             typeof prop.maxLength === "number" ? prop.maxLength : undefined,
-          pattern: this.getStringValue(prop.pattern),
+          pattern:
+            InputSchemaService.VALIDATION_PATTERN_OVERRIDES[key] ||
+            this.getStringValue(prop.pattern),
           format: this.getStringValue(prop.format),
         },
         placeholder:


### PR DESCRIPTION
Enforce hotspot residues validation with format: A12, AB20 (no more than 2 characters chain, no `-` separator)
Fix duplicated selected hotspot residues