### PR TITLE
SBP-524: remove chains field, extract chains from selected residues and exclude chains from RFDiffusion

### DIFF
--- a/src/app/features/workflows/de-novo-design/de-novo-design.html
+++ b/src/app/features/workflows/de-novo-design/de-novo-design.html
@@ -291,7 +291,7 @@
                       } }
 
                       <!-- Number of designs + credits -->
-                      <div class="flex flex-col border rounded-lg p-4 gap-4">
+                      <div class="flex flex-col gap-4">
                         @for (field of schemaLoader.requiredInputFields(); track
                         field.name) { @if (field.name ===
                         'number_of_final_designs') {

--- a/src/app/features/workflows/de-novo-design/de-novo-design.html
+++ b/src/app/features/workflows/de-novo-design/de-novo-design.html
@@ -252,8 +252,8 @@
                       field.name) { @if (field.name === 'starting_pdb' ||
                       field.name === 'max_length' || field.name ===
                       'binder_name' || field.name === 'id' || field.name ===
-                      'number_of_final_designs') {
-                      <!-- skip -->
+                      'number_of_final_designs' || field.name === 'chains') {
+                      <!-- skip: chains are derived from hotspot residues at submission time -->
                       } @else if (field.name === 'min_length') {
                       <div>
                         <p class="block text-sm font-medium mb-1">
@@ -277,16 +277,6 @@
                         [errorMessage]="getRowFieldError(row.id, field.name) || ''"
                         tooltip="Type residues as ChainResidue, e.g. A100,A101,B200. Or click residues in the viewer to add them here."
                         (valueChange)="onHotspotResiduesManualChange(row.id, $event)"
-                        (fieldBlur)="validateRowField(row.id, field.name)"
-                      ></app-form-field>
-                      } @else if (field.name === 'chains') {
-                      <app-form-field
-                        [field]="field"
-                        [value]="getRowValue(row.id, field.name)"
-                        [hasError]="hasRowFieldError(row.id, field.name)"
-                        [errorMessage]="getRowFieldError(row.id, field.name) || ''"
-                        tooltip="Enter chain letter(s) to target, e.g. A or A,B. Auto-filled when you select hotspot residues in the viewer."
-                        (valueChange)="updateRowValueWithValidation(row.id, field.name, $event)"
                         (fieldBlur)="validateRowField(row.id, field.name)"
                       ></app-form-field>
                       } @else {

--- a/src/app/features/workflows/de-novo-design/de-novo-design.spec.ts
+++ b/src/app/features/workflows/de-novo-design/de-novo-design.spec.ts
@@ -212,10 +212,11 @@ describe("DeNovoDesignComponent", () => {
       expect(component.isFormValid()).toBe(false);
     });
 
-    it("ignores binder_name and id required fields", () => {
+    it("ignores binder_name, id, and chains required fields", () => {
       schemaLoader.requiredInputFields.set([
         requiredField("binder_name"),
         requiredField("id"),
+        requiredField("chains"),
       ]);
       schemaLoader.inputRows.set([rowWith({})]);
       expect(component.isFormValid()).toBe(true);
@@ -328,43 +329,10 @@ describe("DeNovoDesignComponent", () => {
   describe("row field validation", () => {
     beforeEach(() => {
       schemaLoader.inputSchemaFields.set([
-        field({ name: "chains" }),
+        field({ name: "some_field" }),
         field({ name: "target_hotspot_residues" }),
       ]);
       schemaLoader.inputRows.set([rowWith({})]);
-    });
-
-    it("passes valid chains present in the PDB", () => {
-      component.pdbResidueMap.set(new Map([["A", new Set([1])]]));
-      component.updateRowValueWithValidation("row1", "chains", "A");
-      expect(component.getRowFieldError("row1", "chains")).toBeNull();
-    });
-
-    it("rejects a chain with invalid characters", () => {
-      component.updateRowValueWithValidation("row1", "chains", "A1");
-      expect(component.hasRowFieldError("row1", "chains")).toBe(true);
-    });
-
-    it("rejects a chain not found in the PDB", () => {
-      component.pdbResidueMap.set(new Map([["A", new Set([1])]]));
-      component.updateRowValueWithValidation("row1", "chains", "B");
-      expect(component.getRowFieldError("row1", "chains")).toContain(
-        "not found in PDB"
-      );
-    });
-
-    it("rejects a hotspot chain not listed in chains", () => {
-      component.pdbResidueMap.set(
-        new Map([
-          ["A", new Set([1])],
-          ["B", new Set([12])],
-        ])
-      );
-      component.updateRowValue("row1", "target_hotspot_residues", "B12");
-      component.updateRowValueWithValidation("row1", "chains", "A");
-      expect(component.getRowFieldError("row1", "chains")).toContain(
-        "Target Hotspot Residues"
-      );
     });
 
     it("passes a valid hotspot residue", () => {
@@ -464,8 +432,10 @@ describe("DeNovoDesignComponent", () => {
         valid: false,
         errors: ["required"],
       });
-      component.updateRowValueWithValidation("row1", "chains", "A");
-      expect(component.getRowFieldError("row1", "chains")).toBe("required");
+      component.updateRowValueWithValidation("row1", "some_field", "A");
+      expect(component.getRowFieldError("row1", "some_field")).toBe(
+        "required"
+      );
     });
 
     it("reports config-section errors including the job name", () => {
@@ -478,7 +448,6 @@ describe("DeNovoDesignComponent", () => {
   describe("field-driven handlers", () => {
     beforeEach(() => {
       schemaLoader.inputSchemaFields.set([
-        field({ name: "chains" }),
         field({ name: "target_hotspot_residues" }),
         field({ name: "min_length", type: "number" }),
         field({ name: "max_length", type: "number" }),
@@ -486,7 +455,7 @@ describe("DeNovoDesignComponent", () => {
       schemaLoader.inputRows.set([rowWith({})]);
     });
 
-    it("derives chains and pushes viewer selection on manual hotspot change", () => {
+    it("pushes viewer selection on manual hotspot change", () => {
       component.pdbResidueMap.set(
         new Map([
           ["A", new Set([56])],
@@ -494,20 +463,18 @@ describe("DeNovoDesignComponent", () => {
         ])
       );
       component.onHotspotResiduesManualChange("row1", "A56,B12");
-      expect(component.getRowValue("row1", "chains")).toBe("A,B");
+      expect(component.getRowValue("row1", "target_hotspot_residues")).toBe(
+        "A56,B12"
+      );
       expect(component.programmaticViewerSelection()).toBe("A56,B12");
     });
 
-    it("auto-fills chains when residues are selected in the viewer", () => {
+    it("updates hotspot residues when selected in the viewer", () => {
       component.pdbResidueMap.set(new Map([["A", new Set([56])]]));
       component.onResiduesSelected("row1", "A56");
-      expect(component.getRowValue("row1", "chains")).toBe("A");
-    });
-
-    it("stores detected chains", () => {
-      component.pdbResidueMap.set(new Map([["A", new Set([1])]]));
-      component.onChainsDetected("row1", "A");
-      expect(component.getRowValue("row1", "chains")).toBe("A");
+      expect(component.getRowValue("row1", "target_hotspot_residues")).toBe(
+        "A56"
+      );
     });
 
     it("flags a structure that is too small", () => {
@@ -780,6 +747,35 @@ describe("DeNovoDesignComponent", () => {
       expect(pdbUpload.uploadPdbFile).toHaveBeenCalled();
       expect(datasetUpload.uploadDataset).toHaveBeenCalled();
       expect(workflowSubmission.submitWorkflowWithDataset).toHaveBeenCalled();
+    });
+
+    it("derives deduplicated chains from hotspot residues for bindcraft", () => {
+      component.formData.set({ target_hotspot_residues: "A12,A13" });
+      datasetUpload.uploadDataset.and.returnValue(
+        of({ message: "", success: true, s3Key: "key-123" })
+      );
+
+      component["performSubmit"]();
+
+      expect(workflowSubmission.submitWorkflowWithDataset).toHaveBeenCalled();
+      const payload = workflowSubmission.submitWorkflowWithDataset.calls.mostRecent()
+        .args[0] as Record<string, unknown>;
+      expect(payload["chains"]).toBe("A");
+    });
+
+    it("omits chains from the payload for rfdiffusion", () => {
+      component.selectTool("rfdiffusion");
+      component.formData.set({
+        target_hotspot_residues: "A12,B5",
+        starting_pdb: "s3://bucket/target.pdb",
+      });
+
+      component["performSubmit"]();
+
+      expect(workflowSubmission.submitWorkflowWithDataset).toHaveBeenCalled();
+      const payload = workflowSubmission.submitWorkflowWithDataset.calls.mostRecent()
+        .args[0] as Record<string, unknown>;
+      expect("chains" in payload).toBe(false);
     });
 
     it("falls back to the file name when the upload returns no URI", () => {

--- a/src/app/features/workflows/de-novo-design/de-novo-design.spec.ts
+++ b/src/app/features/workflows/de-novo-design/de-novo-design.spec.ts
@@ -433,9 +433,7 @@ describe("DeNovoDesignComponent", () => {
         errors: ["required"],
       });
       component.updateRowValueWithValidation("row1", "some_field", "A");
-      expect(component.getRowFieldError("row1", "some_field")).toBe(
-        "required"
-      );
+      expect(component.getRowFieldError("row1", "some_field")).toBe("required");
     });
 
     it("reports config-section errors including the job name", () => {
@@ -758,8 +756,9 @@ describe("DeNovoDesignComponent", () => {
       component["performSubmit"]();
 
       expect(workflowSubmission.submitWorkflowWithDataset).toHaveBeenCalled();
-      const payload = workflowSubmission.submitWorkflowWithDataset.calls.mostRecent()
-        .args[0] as Record<string, unknown>;
+      const payload =
+        workflowSubmission.submitWorkflowWithDataset.calls.mostRecent()
+          .args[0] as Record<string, unknown>;
       expect(payload["chains"]).toBe("A");
     });
 
@@ -773,8 +772,9 @@ describe("DeNovoDesignComponent", () => {
       component["performSubmit"]();
 
       expect(workflowSubmission.submitWorkflowWithDataset).toHaveBeenCalled();
-      const payload = workflowSubmission.submitWorkflowWithDataset.calls.mostRecent()
-        .args[0] as Record<string, unknown>;
+      const payload =
+        workflowSubmission.submitWorkflowWithDataset.calls.mostRecent()
+          .args[0] as Record<string, unknown>;
       expect("chains" in payload).toBe(false);
     });
 

--- a/src/app/features/workflows/de-novo-design/de-novo-design.ts
+++ b/src/app/features/workflows/de-novo-design/de-novo-design.ts
@@ -145,7 +145,12 @@ export default class DeNovoDesignComponent
     const requiredFields = this.schemaLoader.requiredInputFields();
     return rows.every((row) =>
       requiredFields.every((field) => {
-        if (field.name === "binder_name" || field.name === "id") return true;
+        if (
+          field.name === "binder_name" ||
+          field.name === "id" ||
+          field.name === "chains"
+        )
+          return true;
         const value = row.values[field.name];
         return value !== undefined && value !== null && value !== "";
       })
@@ -297,7 +302,6 @@ export default class DeNovoDesignComponent
     // If replacing an existing file, clear only structure-derived fields;
     // min_length, max_length, and pdbSequenceLength stay at schema defaults.
     if (this.localPdbFile()) {
-      this.updateRowValue(rowId, "chains", "");
       this.updateRowValue(rowId, "target_hotspot_residues", "");
       this.programmaticViewerSelection.set("");
     }
@@ -314,69 +318,13 @@ export default class DeNovoDesignComponent
     this.pdbResidueMap.set(null);
     this.programmaticViewerSelection.set("");
     this.updateRowValueWithValidation(rowId, "starting_pdb", "");
-    this.updateRowValueWithValidation(rowId, "chains", "");
     this.updateRowValueWithValidation(rowId, "target_hotspot_residues", "");
-  }
-
-  /** Return sorted, deduplicated chain letters from a residue string like "A56,B12,B13". */
-  private chainsFromResidues(residues: string): string {
-    return [
-      ...new Set(
-        residues
-          .split(",")
-          .map((r) => r.trim().match(/^([A-Za-z]+)/)?.[1] ?? "")
-          .filter(Boolean)
-      ),
-    ]
-      .sort()
-      .join(",");
   }
 
   /** Receives the chain→residue map emitted by the Mol* viewer after it
    *  parses the PDB structure — no need to re-parse the file ourselves. */
   onStructureResiduesDetected(residues: Map<string, Set<number>>): void {
     this.pdbResidueMap.set(residues.size > 0 ? residues : null);
-  }
-
-  private validateChains(rowId: string, value: string): string | null {
-    if (!value?.trim()) return null;
-    const tokens = value
-      .split(",")
-      .map((t) => t.trim())
-      .filter(Boolean);
-
-    for (const token of tokens) {
-      if (!/^[A-Za-z]+$/.test(token)) {
-        return `Invalid chain "${token}". Use letter identifiers only, e.g. "A" or "A,B"`;
-      }
-    }
-
-    const residueMap = this.pdbResidueMap();
-    if (residueMap) {
-      for (const token of tokens) {
-        if (!residueMap.has(token)) {
-          return `Chain "${token}" not found in PDB. Available: ${[
-            ...residueMap.keys(),
-          ]
-            .sort()
-            .join(", ")}`;
-        }
-      }
-    }
-
-    const hotspot =
-      (this.getRowValue(rowId, "target_hotspot_residues") as string) ?? "";
-    if (hotspot.trim()) {
-      const chainsSet = new Set(tokens);
-      for (const hChain of this.chainsFromResidues(hotspot)
-        .split(",")
-        .filter(Boolean)) {
-        if (!chainsSet.has(hChain)) {
-          return `Chain "${hChain}" is used in Target Hotspot Residues but not listed in Chains`;
-        }
-      }
-    }
-    return null;
   }
 
   private validateHotspotResidues(value: string): string | null {
@@ -428,8 +376,8 @@ export default class DeNovoDesignComponent
   programmaticViewerSelection = signal<string>("");
 
   /** Called when the user manually edits the target_hotspot_residues field.
-   *  Updates the value, auto-derives chains, validates against the PDB, and
-   *  pushes the new selection string to the Mol* viewer. */
+   *  Updates the value, validates against the PDB, and pushes the new
+   *  selection string to the Mol* viewer. */
   onHotspotResiduesManualChange(rowId: string, value: unknown): void {
     const residues = (value as string) ?? "";
     this.updateRowValueWithValidation(
@@ -437,13 +385,7 @@ export default class DeNovoDesignComponent
       "target_hotspot_residues",
       residues
     );
-    const chains = this.chainsFromResidues(residues);
-    if (chains) this.updateRowValueWithValidation(rowId, "chains", chains);
     this.programmaticViewerSelection.set(residues);
-  }
-
-  onChainsDetected(rowId: string, chains: string): void {
-    this.updateRowValueWithValidation(rowId, "chains", chains);
   }
 
   onSequenceLengthDetected(count: number): void {
@@ -476,18 +418,13 @@ export default class DeNovoDesignComponent
     this.updateRowValueWithValidation(rowId, "max_length", range.max);
   }
 
-  /** Called when the user selects residues in the Mol* viewer.
-   *  Also derives the unique chain letters (first char of each token)
-   *  and auto-fills the chains field. e.g. "A56,B12" → chains = "A,B".
-   */
+  /** Called when the user selects residues in the Mol* viewer. */
   onResiduesSelected(rowId: string, residues: string): void {
     this.updateRowValueWithValidation(
       rowId,
       "target_hotspot_residues",
       residues
     );
-    const chains = this.chainsFromResidues(residues);
-    this.updateRowValueWithValidation(rowId, "chains", chains);
   }
 
   onFileSelected(event: Event) {
@@ -624,7 +561,6 @@ export default class DeNovoDesignComponent
     this.validateAllRequiredFields();
     for (const row of this.schemaLoader.inputRows()) {
       this.validateRowField(row.id, "target_hotspot_residues");
-      this.validateRowField(row.id, "chains");
     }
   }
 
@@ -674,6 +610,22 @@ export default class DeNovoDesignComponent
     this.doSubmitWorkflow();
   }
 
+  /** Sorted, deduplicated chain letters from a residue string like
+   *  "A56,B12,B13" -> "A,B" — used only to build the BindCraft submission
+   *  payload, not for user-facing chain input. */
+  private extractChainsForSubmission(residues: string): string {
+    return [
+      ...new Set(
+        residues
+          .split(",")
+          .map((r) => r.trim().match(/^([A-Za-z]+)/)?.[1] ?? "")
+          .filter(Boolean)
+      ),
+    ]
+      .sort()
+      .join(",");
+  }
+
   private doSubmitWorkflow(): void {
     const rawFormData = this.getFormData();
     const formData = {
@@ -683,6 +635,19 @@ export default class DeNovoDesignComponent
       binder_name: this.jobName(),
       runName: this.jobName(),
     };
+
+    // BindCraft submits a target chain list derived from the selected hotspot
+    // residues (deduplicated, e.g. "A12,A13" -> "A"). RFDiffusion doesn't take
+    // a chains input at all, so it's omitted from the payload entirely.
+    const formDataRecord = formData as Record<string, unknown>;
+    if (this.selectedTool() === "bindcraft") {
+      const hotspotResidues =
+        (formDataRecord["target_hotspot_residues"] as string) ?? "";
+      formDataRecord["chains"] =
+        this.extractChainsForSubmission(hotspotResidues);
+    } else {
+      delete formDataRecord["chains"];
+    }
 
     this.workflowSubmission.isSubmitting.set(true);
 
@@ -855,7 +820,12 @@ export default class DeNovoDesignComponent
 
     // Validate each required field to show specific errors
     for (const field of requiredFields) {
-      if (field.name === "binder_name" || field.name === "id") continue;
+      if (
+        field.name === "binder_name" ||
+        field.name === "id" ||
+        field.name === "chains"
+      )
+        continue;
       const value = currentData[field.name];
       this.validateField(field.name, value);
     }
@@ -926,6 +896,7 @@ export default class DeNovoDesignComponent
       "settings_advanced",
       "binder_name",
       "id",
+      "chains",
     ];
 
     fields.forEach((field) => {
@@ -1061,8 +1032,6 @@ export default class DeNovoDesignComponent
       let customError: string | null = null;
       if (fieldName === "target_hotspot_residues") {
         customError = this.validateHotspotResidues(value as string);
-      } else if (fieldName === "chains") {
-        customError = this.validateChains(rowId, value as string);
       }
       if (customError) {
         this.formErrors.set({ ...currentErrors, [errorKey]: customError });
@@ -1095,12 +1064,9 @@ export default class DeNovoDesignComponent
   /** Returns true when any field inside the collapsible config section has a validation error. */
   hasConfigSectionErrors(rowId: string): boolean {
     if (this.hasJobNameError()) return true;
-    return [
-      "target_hotspot_residues",
-      "chains",
-      "min_length",
-      "max_length",
-    ].some((f) => this.hasRowFieldError(rowId, f));
+    return ["target_hotspot_residues", "min_length", "max_length"].some((f) =>
+      this.hasRowFieldError(rowId, f)
+    );
   }
 
   // Update row value with validation


### PR DESCRIPTION
<!--
Thank you for contributing! Please fill out the sections below to help maintainers review your change faster.
Delete any sections that don't apply.
-->

# Pull Request

## Summary

[SBP-524](https://biocloud.atlassian.net/browse/SBP-524) — Removes the user-facing "Chains" field from De Novo Design; chains are now derived automatically from the selected hotspot residues at submission time.

## Changes

- Removed the `chains` input field and its panel row from `de-novo-design.html`.
- Removed all chain-autofill logic previously wired to the Mol\* viewer/hotspot editing (`chainsFromResidues`, `validateChains`, `onChainsDetected`, and the chain-derivation calls in `onHotspotResiduesManualChange`, `onResiduesSelected`, `onPdbFilePicked`, `clearLocalPdb`).
- `chains` is excluded from required-field validation and the review summary, since it's no longer user-editable.
- Added `extractChainsForSubmission()`: derives a deduplicated, sorted chain list from `target_hotspot_residues` (e.g. `A12,A13` → `A`).
- Submission payload: for **BindCraft**, `chains` is computed and included; for **RFdiffusion**, `chains` is omitted from the payload entirely.
- Updated specs to match.

## How to Test

1. Open Binder Design → De Novo Design; confirm there is no "Chains" field in the Input Configuration panel.
2. Select BindCraft, upload a PDB, select hotspot residues on the same chain (e.g. A12, A13), and submit; confirm the submitted payload includes `chains: "A"`.
3. Select RFdiffusion and submit; confirm the payload has no `chains` key.
4. `npm test` passes.

## Demo
<img width="1474" height="840" alt="Screenshot 2026-07-30 at 1 43 22 pm" src="https://github.com/user-attachments/assets/1b70d377-19a6-4276-94a3-2e84981bb325" />
<img width="1474" height="840" alt="Screenshot 2026-07-30 at 1 43 42 pm" src="https://github.com/user-attachments/assets/4ddbf482-ddd8-48bb-856a-a64a9802cd97" />
<img width="1474" height="840" alt="Screenshot 2026-07-30 at 1 43 53 pm" src="https://github.com/user-attachments/assets/d575395e-0b2e-49d5-afca-9f5cdc0251db" />
<img width="1474" height="840" alt="Screenshot 2026-07-30 at 1 44 14 pm" src="https://github.com/user-attachments/assets/71b99fe1-0eb4-42be-ac3d-983b89acec84" />


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added or updated documentation where necessary
- [x] I have run linting and unit tests locally
- [x] The code follows the project's style guidelines


[SBP-524]: https://biocloud.atlassian.net/browse/SBP-524?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ