### PR TITLE
fix: flashing post login

### DIFF
--- a/src/app/core/services/auth.service.spec.ts
+++ b/src/app/core/services/auth.service.spec.ts
@@ -405,37 +405,34 @@ describe("AuthService", () => {
   });
 
   describe("General error handling", () => {
-    it("should show error banner and automatically logout after 3 seconds on authentication error", (done) => {
+    it("should show a persistent error banner and immediately clear the session locally, without a redirect", fakeAsync(() => {
       const error = { error: "email_not_verified" };
 
-      // Reset the spy call count
       (mockAuth0Service.logout as jasmine.Spy).calls.reset();
 
-      // Track banner visibility
-      let bannerShown = false;
-      service.showBanner$.subscribe((visible) => {
-        if (visible && !bannerShown) {
-          bannerShown = true;
-          expect(service.currentBannerMessage).toBe("email_not_verified");
-          expect(service.currentBannerType).toBe("error");
+      errorSubject.next(error);
 
-          // Check that logout will be called after 3 seconds
-          setTimeout(() => {
-            expect(mockAuth0Service.logout).toHaveBeenCalledWith({
-              logoutParams: {
-                returnTo: window.location.origin,
-              },
-            });
-            done();
-          }, 3100); // Slightly more than 3 seconds to ensure timeout completes
-        }
+      expect(service.currentBannerMessage).toBe("email_not_verified");
+      expect(service.currentBannerType).toBe("error");
+      expect(service.isBannerVisible).toBe(true);
+
+      // Session cleanup happens right away, and skips the browser redirect
+      // (openUrl: false) so it doesn't interrupt the banner.
+      expect(mockAuth0Service.logout).toHaveBeenCalledWith({
+        openUrl: false,
+        logoutParams: {
+          returnTo: window.location.origin,
+        },
       });
 
-      // Trigger authentication error
-      errorSubject.next(error);
-    });
+      // The banner is not auto-hidden — it stays until dismissError() is called.
+      tick(10000);
+      expect(service.isBannerVisible).toBe(true);
+      expect(service.currentBannerType).toBe("error");
 
-    // retry login functionality removed - authentication errors now show for 3 seconds then trigger automatic logout
+      service.dismissError();
+      expect(service.isBannerVisible).toBe(false);
+    }));
   });
 
   describe("Authentication callback handling", () => {

--- a/src/app/core/services/auth.service.ts
+++ b/src/app/core/services/auth.service.ts
@@ -163,10 +163,8 @@ export class AuthService {
     this.auth0.error$.subscribe((error) => {
       if (error) {
         console.log("Auth error:", error);
-
-        // Show error banner and logout after 3 seconds
         console.log(
-          "Authentication error detected - showing error and logging out"
+          "Authentication error detected - showing persistent error banner"
         );
         this.handleAuthError(error);
       } else {
@@ -199,7 +197,10 @@ export class AuthService {
   }
 
   /**
-   * Handle authentication error by showing error banner and logout after 3 seconds
+   * Handle authentication error by showing an error banner that stays on
+   * screen until the user dismisses it (e.g. access-denied messages point
+   * users to a support link, so a brief auto-hide doesn't give them time to
+   * read or copy it).
    */
   private handleAuthError(error: AuthError): void {
     // Extract and show error message immediately
@@ -210,28 +211,31 @@ export class AuthService {
       "An unexpected error occurred during authentication.";
     this.showBanner(errorMessage, "error");
 
-    // Logout to clear previous session after 3 seconds
-    setTimeout(() => {
-      this.auth0.logout({
-        logoutParams: {
-          returnTo: window.location.origin,
-        },
-      });
-    }, 3000);
+    // Clear the failed session locally (openUrl: false skips the redirect to
+    // Auth0's /v2/logout endpoint) so cleanup doesn't navigate away from the
+    // banner that's still on screen.
+    this.auth0.logout({
+      openUrl: false,
+      logoutParams: {
+        returnTo: window.location.origin,
+      },
+    });
   }
 
   /**
-   * Show banner message for 3 seconds
+   * Show a banner message. Success banners auto-hide after 3 seconds; error
+   * banners stay until dismissed via dismissError().
    */
   private showBanner(message: string, type: "success" | "error"): void {
     this.bannerMessageSubject.next(message);
     this.bannerTypeSubject.next(type);
     this.showBannerSubject.next(true);
 
-    // Auto-hide banner after 3 seconds
-    setTimeout(() => {
-      this.clearBanner();
-    }, 3000);
+    if (type === "success") {
+      setTimeout(() => {
+        this.clearBanner();
+      }, 3000);
+    }
   }
 
   /**


### PR DESCRIPTION
<!--
Thank you for contributing! Please fill out the sections below to help maintainers review your change faster.
Delete any sections that don't apply.
-->

# Pull Request

## Summary

[SBP-447](https://biocloud.atlassian.net/browse/SBP-447): Fixes the fast flashing message after user logs in with revoked access. 

See screen recording below of this issue:

https://github.com/user-attachments/assets/d0972a17-4719-41bc-bccd-a83e1fed94e0


## Changes

- Error banners now persist until the user dismisses them (via the alert's existing dismiss button → `dismissError()`). Success banners ("Login successful!") keep the old 3-second auto-hide.
- Session cleanup no longer navigates away. `handleAuthError()` still clears the failed session via `auth0.logout()`, but with `openUrl: false`, which does a local-only cleanup (clears cached tokens) without redirecting the browser through Auth0's logout endpoint — so it can't interrupt the banner anymore.
- Updated the test 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have added or updated documentation where necessary
- [X] I have run linting and unit tests locally
- [x] The code follows the project's style guidelines


[SBP-447]: https://biocloud.atlassian.net/browse/SBP-447?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ