### PR TITLE
ci(release-please): generate release notes at dev → staging promotion

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -2,7 +2,7 @@ name: release-please
 
 on:
   push:
-    branches: [dev, staging]
+    branches: [staging]
   workflow_dispatch:
 
 permissions:
@@ -24,9 +24,10 @@ jobs:
         with:
           release-type: node
           package-name: sbp-portal
-          # Maintain a separate release line per integration branch: a push to
-          # dev manages the dev release PR, a push to staging manages staging's.
-          target-branch: ${{ github.ref_name }}
+          # Releases are cut at the promotion point. A dev -> staging merge lands
+          # the promoted commits on staging; release-please compiles them into the
+          # staging release PR / notes. dev has no release line of its own.
+          target-branch: staging
           token: ${{ steps.app-token.outputs.token }}
           changelog-types: |
             [

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -2,7 +2,7 @@ name: release-please
 
 on:
   push:
-    branches: [main]
+    branches: [dev, staging]
   workflow_dispatch:
 
 permissions:
@@ -24,6 +24,9 @@ jobs:
         with:
           release-type: node
           package-name: sbp-portal
+          # Maintain a separate release line per integration branch: a push to
+          # dev manages the dev release PR, a push to staging manages staging's.
+          target-branch: ${{ github.ref_name }}
           token: ${{ steps.app-token.outputs.token }}
           changelog-types: |
             [


### PR DESCRIPTION
<!--
Thank you for contributing! Please fill out the sections below to help maintainers review your change faster.
Delete any sections that don't apply.
-->

# Pull Request

## Summary
- Wires up **release-please** to cut releases (version bump, `CHANGELOG.md`, GitHub Release, git tag) from the **`staging`** branch.
- release-please runs on `push: [staging]` with `target-branch: staging`, so a **`dev → staging` promotion** compiles the promoted commits into release notes.
- `dev` has **no** release line of its own — releases exist only at the promotion point (`staging`).
- No deployment impact: deploys are branch-driven (push to `dev`/`staging`); this only adds release notes/versioning on top.

## How to use it
- **Do feature work on `dev`:** open PRs into `dev` and **squash-merge** them, so each feature becomes one clean commit.
- **Promote with a MERGE COMMIT, not a squash:** open a `dev → staging` PR and merge it using **"Create a merge commit"**.
- **After the promotion lands on `staging`,** release-please opens/updates a **release PR** (`release-please--branches--staging--…`) previewing the version bump + notes.
- **Merge that release PR** to publish the **GitHub Release + `CHANGELOG.md` + tag**.

## Activation (important — one-time)
- This workflow only fires once the file exists **on the `staging` branch**. So after merging this PR into `dev`, **promote `dev → staging`** to carry it across; the first release PR appears on that promotion.


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added or updated documentation where necessary
- [x] I have run linting and unit tests locally
- [x] The code follows the project's style guidelines