### PR TITLE
refactor: smiles validation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "als-normalize-urlpath": "^2.3.0",
         "date-fns": "^4.1.0",
         "molstar": "^5.6.1",
+        "openchemlib": "^9.24.0",
         "playwright": "^1.56.0",
         "rxjs": "~7.8.0",
         "tailwindcss": "^4.3.0",
@@ -12723,6 +12724,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/openchemlib": {
+      "version": "9.24.0",
+      "resolved": "https://registry.npmjs.org/openchemlib/-/openchemlib-9.24.0.tgz",
+      "integrity": "sha512-aIZc4wxcIq4d1RK32WAkGjjyFUKPcf2zdlklvzkmmo2HuHTojFUubeSxp0CQ6MZDGLiK18iQJwxA4/O9Db2bvA==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/openid-client": {
       "version": "6.8.4",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "als-normalize-urlpath": "^2.3.0",
     "date-fns": "^4.1.0",
     "molstar": "^5.6.1",
+    "openchemlib": "^9.24.0",
     "playwright": "^1.56.0",
     "rxjs": "~7.8.0",
     "tailwindcss": "^4.3.0",

--- a/src/app/features/workflows/shared/fasta.utils.spec.ts
+++ b/src/app/features/workflows/shared/fasta.utils.spec.ts
@@ -3,6 +3,7 @@ import {
   CCD_COMPOUNDS,
   isValidSmiles,
   parseMultiFasta,
+  validateBulkFastaProtein,
   validateDnaSequence,
   validateFastaHeader,
   validateMultiFastaProtein,
@@ -213,6 +214,10 @@ describe("fasta.utils", () => {
       expect(isValidSmiles("NH4]")).toBe(false);
     });
 
+    it("rejects strings that OCL's parser cannot resolve into a molecule", () => {
+      expect(isValidSmiles("C1CC")).toBe(false);
+    });
+
     it("rejects mismatched mixed brackets", () => {
       expect(isValidSmiles("C([NH4)")).toBe(false);
     });
@@ -323,6 +328,90 @@ describe("fasta.utils", () => {
         valid: true,
         sequenceCount: 1,
       });
+    });
+  });
+
+  describe("validateBulkFastaProtein", () => {
+    it("rejects empty input", () => {
+      expect(validateBulkFastaProtein("")).toEqual({
+        valid: false,
+        errorMessage: "At least one FASTA sequence is required",
+        sequenceCount: 0,
+      });
+    });
+
+    it("rejects input without a FASTA header", () => {
+      expect(validateBulkFastaProtein("MKTAYIAK")).toEqual({
+        valid: false,
+        errorMessage:
+          'Input must be in FASTA format: each entry needs a header line starting with ">".',
+        sequenceCount: 0,
+      });
+    });
+
+    it("rejects an entry with an empty header", () => {
+      expect(validateBulkFastaProtein(">\nMKTAYIAK")).toEqual({
+        valid: false,
+        errorMessage:
+          'FASTA header cannot be empty (the ">" line must contain text after it).',
+        sequenceCount: 0,
+      });
+    });
+
+    it("rejects duplicate headers within the same input", () => {
+      const result = validateBulkFastaProtein(
+        ">seq1\nMKTAYIAK\n>seq1\nACDEFGHIK"
+      );
+      expect(result.valid).toBe(false);
+      expect(result.errorMessage).toContain('Duplicate FASTA header: "seq1"');
+    });
+
+    it("rejects an entry with no sequence after the header", () => {
+      expect(validateBulkFastaProtein(">seq1\n")).toEqual({
+        valid: false,
+        errorMessage: 'No sequence found for header "seq1"',
+        sequenceCount: 0,
+      });
+    });
+
+    it("rejects spaces within sequence content", () => {
+      expect(validateBulkFastaProtein(">seq1\nACD EFG HIK LMN")).toEqual({
+        valid: false,
+        errorMessage: 'Sequence for "seq1" must not contain spaces',
+        sequenceCount: 0,
+      });
+    });
+
+    it("rejects non-canonical amino acid characters", () => {
+      const result = validateBulkFastaProtein(">seq1\nMKTBBBIAK");
+      expect(result.valid).toBe(false);
+      expect(result.errorMessage).toContain('"seq1"');
+      expect(result.errorMessage).toContain("ARNDCQEGHILKMFPSTWYV");
+    });
+
+    it("rejects invalid ':' chain-delimiter placement", () => {
+      const result = validateBulkFastaProtein(">seq1\n:MKTAYIAK");
+      expect(result.valid).toBe(false);
+      expect(result.errorMessage).toContain('invalid ":" placement');
+    });
+
+    it("rejects sequences exceeding the maximum amino-acid length", () => {
+      const result = validateBulkFastaProtein(`>seq1\n${"A".repeat(1001)}`);
+      expect(result.valid).toBe(false);
+      expect(result.errorMessage).toContain("exceeding the maximum of 1000");
+    });
+
+    it("accepts a single valid entry", () => {
+      expect(validateBulkFastaProtein(">seq1\nMKTAYIAK")).toEqual({
+        valid: true,
+        sequenceCount: 1,
+      });
+    });
+
+    it("accepts multiple valid entries with a multimer chain delimiter", () => {
+      expect(
+        validateBulkFastaProtein(">seq1\nMKTAYIAK:ACDEFGHIK\n>seq2\nACDEFGHIK")
+      ).toEqual({ valid: true, sequenceCount: 2 });
     });
   });
 

--- a/src/app/features/workflows/shared/fasta.utils.ts
+++ b/src/app/features/workflows/shared/fasta.utils.ts
@@ -1,3 +1,5 @@
+import { Molecule } from "openchemlib";
+
 export interface SequenceValidationResult {
   valid: boolean;
   errorMessage?: string;
@@ -425,10 +427,14 @@ export function isValidSmiles(value: string): boolean {
     return false;
   }
 
+  // OCL's SMILES parser accepts query-molecule extensions (e.g. "?" as an
+  // any-atom wildcard) that aren't valid for a concrete ligand structure.
   if (!/^[A-Za-z0-9@+\-[\]()=#$\\/%.:*]+$/.test(value)) {
     return false;
   }
 
+  // OCL's SMILES parser silently auto-closes unmatched opening
+  // brackets/parens instead of throwing, so bracket balance is checked here.
   const stack: string[] = [];
   const pairs: Record<string, string> = {
     ")": "(",
@@ -439,12 +445,19 @@ export function isValidSmiles(value: string): boolean {
     if (char === "(" || char === "[") {
       stack.push(char);
     } else if (char === ")" || char === "]") {
-      const expected = pairs[char];
-      if (stack.pop() !== expected) {
+      if (stack.pop() !== pairs[char]) {
         return false;
       }
     }
   }
 
-  return stack.length === 0 && /[A-Za-z]/.test(value);
+  if (stack.length !== 0) {
+    return false;
+  }
+
+  try {
+    return Molecule.fromSmiles(value).getAllAtoms() > 0;
+  } catch {
+    return false;
+  }
 }


### PR DESCRIPTION
# Pull Request

## Summary

[SBP-489](https://biocloud.atlassian.net/browse/SBP-489) — Validate ligand SMILES by parsing with `openchemlib` instead of a hand-rolled check, catching malformed structures the old heuristic missed.

## Changes

- Add `openchemlib` dependency.
- `isValidSmiles` (`fasta.utils.ts`): parse with `Molecule.fromSmiles` and require ≥1 atom; parse failures are rejected.
- Update tests accordingly.

## How to Test

1. `npm test -- --include='**/fasta.utils.spec.ts'`
2. De Novo Design / Single Prediction: invalid SMILES rejected, valid SMILES (e.g. `CCO`) accepted.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added or updated documentation where necessary
- [x] I have run linting and unit tests locally
- [x] The code follows the project's style guidelines


[SBP-489]: https://biocloud.atlassian.net/browse/SBP-489?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ